### PR TITLE
Added Journey covering PRA 1 A-E

### DIFF
--- a/app/controllers/DeprecatedLibrariesController.scala
+++ b/app/controllers/DeprecatedLibrariesController.scala
@@ -16,43 +16,41 @@
 
 package controllers
 
-import controllers.actions.*
-import forms.NonstandardPatternFormProvider
-
+import controllers.actions._
+import forms.DeprecatedLibrariesFormProvider
 import javax.inject.Inject
 import models.Mode
 import navigation.Navigator
-import pages.NonstandardPatternPage
+import pages.DeprecatedLibrariesPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import views.html.NonstandardPatternView
+import views.html.DeprecatedLibrariesView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class NonstandardPatternController @Inject()(
-                                        override val messagesApi: MessagesApi,
-                                        sessionRepository: SessionRepository,
-                                        navigator: Navigator,
-                                        identify: IdentifierAction,
-                                        getData: DataRetrievalAction,
-                                        requireData: DataRequiredAction,
-                                        formProvider: NonstandardPatternFormProvider,
-                                        val controllerComponents: MessagesControllerComponents,
-                                        view: NonstandardPatternView
-                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+class DeprecatedLibrariesController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: DeprecatedLibrariesFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: DeprecatedLibrariesView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
   val form = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
 
-      val preparedForm = request.userAnswers.get(NonstandardPatternPage) match {
+      val preparedForm = request.userAnswers.get(DeprecatedLibrariesPage) match {
         case None => form
         case Some(value) => form.fill(value)
       }
-
 
       Ok(view(preparedForm, mode))
   }
@@ -66,9 +64,9 @@ class NonstandardPatternController @Inject()(
 
         value =>
           for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(NonstandardPatternPage, value))
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(DeprecatedLibrariesPage, value))
             _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(NonstandardPatternPage, mode, updatedAnswers))
+          } yield Redirect(navigator.nextPage(DeprecatedLibrariesPage, mode, updatedAnswers))
       )
   }
 }

--- a/app/controllers/DoesNonstandardPatternController.scala
+++ b/app/controllers/DoesNonstandardPatternController.scala
@@ -16,43 +16,41 @@
 
 package controllers
 
-import controllers.actions.*
-import forms.NonstandardPatternFormProvider
-
+import controllers.actions._
+import forms.DoesNonstandardPatternFormProvider
 import javax.inject.Inject
 import models.Mode
 import navigation.Navigator
-import pages.NonstandardPatternPage
+import pages.DoesNonstandardPatternPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import views.html.NonstandardPatternView
+import views.html.DoesNonstandardPatternView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class NonstandardPatternController @Inject()(
-                                        override val messagesApi: MessagesApi,
-                                        sessionRepository: SessionRepository,
-                                        navigator: Navigator,
-                                        identify: IdentifierAction,
-                                        getData: DataRetrievalAction,
-                                        requireData: DataRequiredAction,
-                                        formProvider: NonstandardPatternFormProvider,
-                                        val controllerComponents: MessagesControllerComponents,
-                                        view: NonstandardPatternView
-                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+class DoesNonstandardPatternController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: DoesNonstandardPatternFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: DoesNonstandardPatternView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
   val form = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
 
-      val preparedForm = request.userAnswers.get(NonstandardPatternPage) match {
+      val preparedForm = request.userAnswers.get(DoesNonstandardPatternPage) match {
         case None => form
         case Some(value) => form.fill(value)
       }
-
 
       Ok(view(preparedForm, mode))
   }
@@ -66,9 +64,9 @@ class NonstandardPatternController @Inject()(
 
         value =>
           for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(NonstandardPatternPage, value))
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(DoesNonstandardPatternPage, value))
             _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(NonstandardPatternPage, mode, updatedAnswers))
+          } yield Redirect(navigator.nextPage(DoesNonstandardPatternPage, mode, updatedAnswers))
       )
   }
 }

--- a/app/controllers/ReadMeFitForPurposeController.scala
+++ b/app/controllers/ReadMeFitForPurposeController.scala
@@ -16,43 +16,41 @@
 
 package controllers
 
-import controllers.actions.*
-import forms.NonstandardPatternFormProvider
-
+import controllers.actions._
+import forms.ReadMeFitForPurposeFormProvider
 import javax.inject.Inject
 import models.Mode
 import navigation.Navigator
-import pages.NonstandardPatternPage
+import pages.ReadMeFitForPurposePage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import views.html.NonstandardPatternView
+import views.html.ReadMeFitForPurposeView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class NonstandardPatternController @Inject()(
-                                        override val messagesApi: MessagesApi,
-                                        sessionRepository: SessionRepository,
-                                        navigator: Navigator,
-                                        identify: IdentifierAction,
-                                        getData: DataRetrievalAction,
-                                        requireData: DataRequiredAction,
-                                        formProvider: NonstandardPatternFormProvider,
-                                        val controllerComponents: MessagesControllerComponents,
-                                        view: NonstandardPatternView
-                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+class ReadMeFitForPurposeController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: ReadMeFitForPurposeFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: ReadMeFitForPurposeView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
   val form = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
 
-      val preparedForm = request.userAnswers.get(NonstandardPatternPage) match {
+      val preparedForm = request.userAnswers.get(ReadMeFitForPurposePage) match {
         case None => form
         case Some(value) => form.fill(value)
       }
-
 
       Ok(view(preparedForm, mode))
   }
@@ -66,9 +64,9 @@ class NonstandardPatternController @Inject()(
 
         value =>
           for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(NonstandardPatternPage, value))
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(ReadMeFitForPurposePage, value))
             _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(NonstandardPatternPage, mode, updatedAnswers))
+          } yield Redirect(navigator.nextPage(ReadMeFitForPurposePage, mode, updatedAnswers))
       )
   }
 }

--- a/app/controllers/ServiceURLController.scala
+++ b/app/controllers/ServiceURLController.scala
@@ -16,31 +16,30 @@
 
 package controllers
 
-import controllers.actions.*
-import forms.NonstandardPatternFormProvider
-
+import controllers.actions._
+import forms.ServiceURLFormProvider
 import javax.inject.Inject
 import models.Mode
 import navigation.Navigator
-import pages.NonstandardPatternPage
+import pages.ServiceURLPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import views.html.NonstandardPatternView
+import views.html.ServiceURLView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class NonstandardPatternController @Inject()(
+class ServiceURLController @Inject()(
                                         override val messagesApi: MessagesApi,
                                         sessionRepository: SessionRepository,
                                         navigator: Navigator,
                                         identify: IdentifierAction,
                                         getData: DataRetrievalAction,
                                         requireData: DataRequiredAction,
-                                        formProvider: NonstandardPatternFormProvider,
+                                        formProvider: ServiceURLFormProvider,
                                         val controllerComponents: MessagesControllerComponents,
-                                        view: NonstandardPatternView
+                                        view: ServiceURLView
                                     )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
   val form = formProvider()
@@ -48,11 +47,10 @@ class NonstandardPatternController @Inject()(
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
 
-      val preparedForm = request.userAnswers.get(NonstandardPatternPage) match {
+      val preparedForm = request.userAnswers.get(ServiceURLPage) match {
         case None => form
         case Some(value) => form.fill(value)
       }
-
 
       Ok(view(preparedForm, mode))
   }
@@ -66,9 +64,9 @@ class NonstandardPatternController @Inject()(
 
         value =>
           for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(NonstandardPatternPage, value))
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(ServiceURLPage, value))
             _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(NonstandardPatternPage, mode, updatedAnswers))
+          } yield Redirect(navigator.nextPage(ServiceURLPage, mode, updatedAnswers))
       )
   }
 }

--- a/app/controllers/UsingHTTPVerbsController.scala
+++ b/app/controllers/UsingHTTPVerbsController.scala
@@ -16,43 +16,41 @@
 
 package controllers
 
-import controllers.actions.*
-import forms.NonstandardPatternFormProvider
-
+import controllers.actions._
+import forms.UsingHTTPVerbsFormProvider
 import javax.inject.Inject
 import models.Mode
 import navigation.Navigator
-import pages.NonstandardPatternPage
+import pages.UsingHTTPVerbsPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import views.html.NonstandardPatternView
+import views.html.UsingHTTPVerbsView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class NonstandardPatternController @Inject()(
-                                        override val messagesApi: MessagesApi,
-                                        sessionRepository: SessionRepository,
-                                        navigator: Navigator,
-                                        identify: IdentifierAction,
-                                        getData: DataRetrievalAction,
-                                        requireData: DataRequiredAction,
-                                        formProvider: NonstandardPatternFormProvider,
-                                        val controllerComponents: MessagesControllerComponents,
-                                        view: NonstandardPatternView
-                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+class UsingHTTPVerbsController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: UsingHTTPVerbsFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: UsingHTTPVerbsView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
   val form = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
 
-      val preparedForm = request.userAnswers.get(NonstandardPatternPage) match {
+      val preparedForm = request.userAnswers.get(UsingHTTPVerbsPage) match {
         case None => form
         case Some(value) => form.fill(value)
       }
-
 
       Ok(view(preparedForm, mode))
   }
@@ -66,9 +64,9 @@ class NonstandardPatternController @Inject()(
 
         value =>
           for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(NonstandardPatternPage, value))
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(UsingHTTPVerbsPage, value))
             _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(NonstandardPatternPage, mode, updatedAnswers))
+          } yield Redirect(navigator.nextPage(UsingHTTPVerbsPage, mode, updatedAnswers))
       )
   }
 }

--- a/app/forms/DeprecatedLibrariesFormProvider.scala
+++ b/app/forms/DeprecatedLibrariesFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class DeprecatedLibrariesFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("deprecatedLibraries.error.required")
+    )
+}

--- a/app/forms/DoesNonstandardPatternFormProvider.scala
+++ b/app/forms/DoesNonstandardPatternFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class DoesNonstandardPatternFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("doesNonstandardPattern.error.required")
+    )
+}

--- a/app/forms/ReadMeFitForPurposeFormProvider.scala
+++ b/app/forms/ReadMeFitForPurposeFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class ReadMeFitForPurposeFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("readMeFitForPurpose.error.required")
+    )
+}

--- a/app/forms/ServiceURLFormProvider.scala
+++ b/app/forms/ServiceURLFormProvider.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class ServiceURLFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[String] =
+    Form(
+      "value" -> text("serviceURL.error.required")
+        .verifying(maxLength(100, "serviceURL.error.length"))
+    )
+}

--- a/app/forms/UsingHTTPVerbsFormProvider.scala
+++ b/app/forms/UsingHTTPVerbsFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class UsingHTTPVerbsFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("usingHTTPVerbs.error.required")
+    )
+}

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -27,8 +27,24 @@ import models._
 class Navigator @Inject()() {
 
   private val normalRoutes: Page => UserAnswers => Call = {
-    case IndexPage => _ => routes.NonstandardPatternController.onPageLoad(NormalMode)
+    case IndexPage => _ => routes.ServiceURLController.onPageLoad(NormalMode)
+
+    case ServiceURLPage => _ => routes.DoesNonstandardPatternController.onPageLoad(NormalMode)
+
+    case DoesNonstandardPatternPage => userAnswers =>
+      userAnswers.get(DoesNonstandardPatternPage) match {
+        case Some(true) => routes.NonstandardPatternController.onPageLoad(NormalMode)
+        case _ => routes.BreakBobbyRulesController.onPageLoad(NormalMode)
+      }
+
     case NonstandardPatternPage => _ => routes.BreakBobbyRulesController.onPageLoad(NormalMode)
+
+    case BreakBobbyRulesPage => _ => routes.DeprecatedLibrariesController.onPageLoad(NormalMode)
+
+    case DeprecatedLibrariesPage => _ => routes.UsingHTTPVerbsController.onPageLoad(NormalMode)
+
+    case UsingHTTPVerbsPage => _ => routes.ReadMeFitForPurposeController.onPageLoad(NormalMode)
+
     case _ => _ => routes.IndexController.onPageLoad()
   }
 

--- a/app/pages/DeprecatedLibrariesPage.scala
+++ b/app/pages/DeprecatedLibrariesPage.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+import play.api.libs.json.JsPath
+
+case object DeprecatedLibrariesPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "deprecatedLibraries"
+}

--- a/app/pages/DoesNonstandardPatternPage.scala
+++ b/app/pages/DoesNonstandardPatternPage.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+import play.api.libs.json.JsPath
+
+case object DoesNonstandardPatternPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "doesNonstandardPattern"
+}

--- a/app/pages/ReadMeFitForPurposePage.scala
+++ b/app/pages/ReadMeFitForPurposePage.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+import play.api.libs.json.JsPath
+
+case object ReadMeFitForPurposePage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "readMeFitForPurpose"
+}

--- a/app/pages/ServiceURLPage.scala
+++ b/app/pages/ServiceURLPage.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+import play.api.libs.json.JsPath
+
+case object ServiceURLPage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "serviceURL"
+}

--- a/app/pages/UsingHTTPVerbsPage.scala
+++ b/app/pages/UsingHTTPVerbsPage.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+import play.api.libs.json.JsPath
+
+case object UsingHTTPVerbsPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "usingHTTPVerbs"
+}

--- a/app/viewmodels/checkAnswers/DeprecatedLibrariesSummary.scala
+++ b/app/viewmodels/checkAnswers/DeprecatedLibrariesSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.DeprecatedLibrariesPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object DeprecatedLibrariesSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(DeprecatedLibrariesPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "deprecatedLibraries.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.DeprecatedLibrariesController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("deprecatedLibraries.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/DoesNonstandardPatternSummary.scala
+++ b/app/viewmodels/checkAnswers/DoesNonstandardPatternSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.DoesNonstandardPatternPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object DoesNonstandardPatternSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(DoesNonstandardPatternPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "doesNonstandardPattern.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.DoesNonstandardPatternController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("doesNonstandardPattern.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/ReadMeFitForPurposeSummary.scala
+++ b/app/viewmodels/checkAnswers/ReadMeFitForPurposeSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.ReadMeFitForPurposePage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object ReadMeFitForPurposeSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(ReadMeFitForPurposePage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "readMeFitForPurpose.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.ReadMeFitForPurposeController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("readMeFitForPurpose.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/ServiceURLSummary.scala
+++ b/app/viewmodels/checkAnswers/ServiceURLSummary.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.ServiceURLPage
+import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object ServiceURLSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(ServiceURLPage).map {
+      answer =>
+
+        SummaryListRowViewModel(
+          key     = "serviceURL.checkYourAnswersLabel",
+          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.ServiceURLController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("serviceURL.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/UsingHTTPVerbsSummary.scala
+++ b/app/viewmodels/checkAnswers/UsingHTTPVerbsSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.UsingHTTPVerbsPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object UsingHTTPVerbsSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(UsingHTTPVerbsPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "usingHTTPVerbs.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.UsingHTTPVerbsController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("usingHTTPVerbs.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/views/DeprecatedLibrariesView.scala.html
+++ b/app/views/DeprecatedLibrariesView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("deprecatedLibraries.title"))) {
+
+    @formHelper(action = routes.DeprecatedLibrariesController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("deprecatedLibraries.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/DoesNonstandardPatternView.scala.html
+++ b/app/views/DoesNonstandardPatternView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("doesNonstandardPattern.title"))) {
+
+    @formHelper(action = routes.DoesNonstandardPatternController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("doesNonstandardPattern.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/ReadMeFitForPurposeView.scala.html
+++ b/app/views/ReadMeFitForPurposeView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("readMeFitForPurpose.title"))) {
+
+    @formHelper(action = routes.ReadMeFitForPurposeController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("readMeFitForPurpose.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/ServiceURLView.scala.html
+++ b/app/views/ServiceURLView.scala.html
@@ -1,0 +1,49 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.InputWidth._
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukInput: GovukInput,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("serviceURL.title"))) {
+
+    @formHelper(action = routes.ServiceURLController.onSubmit(mode)) {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukInput(
+            InputViewModel(
+                field = form("value"),
+                label = LabelViewModel(messages("serviceURL.heading")).asPageHeading()
+            )
+            .withWidth(Full)
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/UsingHTTPVerbsView.scala.html
+++ b/app/views/UsingHTTPVerbsView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("usingHTTPVerbs.title"))) {
+
+    @formHelper(action = routes.UsingHTTPVerbsController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("usingHTTPVerbs.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -20,12 +20,37 @@ GET         /account/signed-out                          controllers.auth.Signed
 
 GET         /unauthorised                                controllers.UnauthorisedController.onPageLoad()
 
-GET         /nonstandard-pattern                         controllers.NonstandardPatternController.onPageLoad(mode: Mode = NormalMode)
-POST        /nonstandard-pattern                         controllers.NonstandardPatternController.onSubmit(mode: Mode = NormalMode)
-GET         /change-nonstandard-pattern                  controllers.NonstandardPatternController.onPageLoad(mode: Mode = CheckMode)
-POST        /change-nonstandard-pattern                  controllers.NonstandardPatternController.onSubmit(mode: Mode = CheckMode)
+GET         /does-nonstandard-pattern                    controllers.DoesNonstandardPatternController.onPageLoad(mode: Mode = NormalMode)
+POST        /does-nonstandard-pattern                    controllers.DoesNonstandardPatternController.onSubmit(mode: Mode = NormalMode)
+GET         /change-does-nonstandard-pattern             controllers.DoesNonstandardPatternController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-does-nonstandard-pattern             controllers.DoesNonstandardPatternController.onSubmit(mode: Mode = CheckMode)
+
+GET         /which-nonstandard-pattern                   controllers.NonstandardPatternController.onPageLoad(mode: Mode = NormalMode)
+POST        /which-nonstandard-pattern                   controllers.NonstandardPatternController.onSubmit(mode: Mode = NormalMode)
+GET         /change-which-nonstandard-pattern            controllers.NonstandardPatternController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-which-nonstandard-pattern            controllers.NonstandardPatternController.onSubmit(mode: Mode = CheckMode)
 
 GET         /break-bobby-rules                           controllers.BreakBobbyRulesController.onPageLoad(mode: Mode = NormalMode)
 POST        /break-bobby-rules                           controllers.BreakBobbyRulesController.onSubmit(mode: Mode = NormalMode)
 GET         /change-break-bobby-rules                    controllers.BreakBobbyRulesController.onPageLoad(mode: Mode = CheckMode)
 POST        /change-break-bobby-rules                    controllers.BreakBobbyRulesController.onSubmit(mode: Mode = CheckMode)
+
+GET         /using-http-verbs                            controllers.UsingHTTPVerbsController.onPageLoad(mode: Mode = NormalMode)
+POST        /using-http-verbs                            controllers.UsingHTTPVerbsController.onSubmit(mode: Mode = NormalMode)
+GET         /change-using-http-verbs                     controllers.UsingHTTPVerbsController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-using-http-verbs                     controllers.UsingHTTPVerbsController.onSubmit(mode: Mode = CheckMode)
+
+GET         /deprecated-libraries                        controllers.DeprecatedLibrariesController.onPageLoad(mode: Mode = NormalMode)
+POST        /deprecated-libraries                        controllers.DeprecatedLibrariesController.onSubmit(mode: Mode = NormalMode)
+GET         /change-deprecated-libraries                 controllers.DeprecatedLibrariesController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-deprecated-libraries                 controllers.DeprecatedLibrariesController.onSubmit(mode: Mode = CheckMode)
+
+GET         /service-url                                 controllers.ServiceURLController.onPageLoad(mode: Mode = NormalMode)
+POST        /service-url                                 controllers.ServiceURLController.onSubmit(mode: Mode = NormalMode)
+GET         /change-service-url                          controllers.ServiceURLController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-service-url                          controllers.ServiceURLController.onSubmit(mode: Mode = CheckMode)
+
+GET         /read-me-fit-for-purpose                     controllers.ReadMeFitForPurposeController.onPageLoad(mode: Mode = NormalMode)
+POST        /read-me-fit-for-purpose                     controllers.ReadMeFitForPurposeController.onSubmit(mode: Mode = NormalMode)
+GET         /change-read-me-fit-for-purpose              controllers.ReadMeFitForPurposeController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-read-me-fit-for-purpose              controllers.ReadMeFitForPurposeController.onSubmit(mode: Mode = CheckMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -48,6 +48,13 @@ signedOut.guidance = We did not save your answers.
 unauthorised.title = You can’t access this service with this account
 unauthorised.heading = You can’t access this service with this account
 
+serviceURL.title = What is the service page URL for your service within the MDPT Catalogue?
+serviceURL.heading = What is the service page URL for your service within the MDPT Catalogue?
+serviceURL.checkYourAnswersLabel = serviceURL
+serviceURL.error.required = Enter serviceURL
+serviceURL.error.length = ServiceURL must be 100 characters or less
+serviceURL.change.hidden = ServiceURL
+
 nonstandardPattern.title = What non-standard patterns are implemented on your service?
 nonstandardPattern.heading = What non-standard patterns are implemented on your service?
 nonstandardPattern.checkYourAnswersLabel = nonstandardPattern
@@ -55,8 +62,32 @@ nonstandardPattern.error.required = Enter any non-standard patterns which may be
 nonstandardPattern.error.length = This text must be 100 characters or less
 nonstandardPattern.change.hidden = NonstandardPattern
 
+doesNonstandardPattern.title = Does your service implement any non-standard patterns, or contradict any of the MDTP Opinions?
+doesNonstandardPattern.heading = Does your service implement any non-standard patterns, or contradict any of the MDTP Opinions?
+doesNonstandardPattern.checkYourAnswersLabel = doesNonstandardPattern
+doesNonstandardPattern.error.required = Select yes if your service implements any non-standard patterns, or contradicts any MDTP Opinions
+doesNonstandardPattern.change.hidden = DoesNonstandardPattern
+
 breakBobbyRules.title = Does your service break any Bobby Rules?
 breakBobbyRules.heading = Does your service break any Bobby Rules?
 breakBobbyRules.checkYourAnswersLabel = breakBobbyRules
-breakBobbyRules.error.required = Select yes if breakBobbyRules
+breakBobbyRules.error.required = Select yes if your service breaks any Bobby Rules
 breakBobbyRules.change.hidden = BreakBobbyRules
+
+usingHTTPVerbs.title = Are you using HTTP Verbs in your outbound calls?
+usingHTTPVerbs.heading = Are you using HTTP Verbs in your outbound calls?
+usingHTTPVerbs.checkYourAnswersLabel = usingHTTPVerbs
+usingHTTPVerbs.error.required = Select yes if your service uses HTTP Verbs in outbound calls
+usingHTTPVerbs.change.hidden = UsingHTTPVerbs
+
+deprecatedLibraries.title = Is your service using any deprecated HMRC Libraries?
+deprecatedLibraries.heading = Is your service using any deprecated HMRC Libraries?
+deprecatedLibraries.checkYourAnswersLabel = deprecatedLibraries
+deprecatedLibraries.error.required = Select yes if your service is using deprecated HMRC Libraries
+deprecatedLibraries.change.hidden = DeprecatedLibraries
+
+readMeFitForPurpose.title = Is your service(s) ReadMe document(s) up to date and fit for purpose?
+readMeFitForPurpose.heading = Is your service(s) ReadMe document(s) up to date and fit for purpose?
+readMeFitForPurpose.checkYourAnswersLabel = readMeFitForPurpose
+readMeFitForPurpose.error.required = Select yes if your service(s) ReadMe document(s) are both up to date and are fit for purpose
+readMeFitForPurpose.change.hidden = ReadMeFitForPurpose

--- a/test/controllers/DeprecatedLibrariesControllerSpec.scala
+++ b/test/controllers/DeprecatedLibrariesControllerSpec.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import forms.DeprecatedLibrariesFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.DeprecatedLibrariesPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.DeprecatedLibrariesView
+
+import scala.concurrent.Future
+
+class DeprecatedLibrariesControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new DeprecatedLibrariesFormProvider()
+  val form = formProvider()
+
+  lazy val deprecatedLibrariesRoute = routes.DeprecatedLibrariesController.onPageLoad(NormalMode).url
+
+  "DeprecatedLibraries Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, deprecatedLibrariesRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[DeprecatedLibrariesView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(DeprecatedLibrariesPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, deprecatedLibrariesRoute)
+
+        val view = application.injector.instanceOf[DeprecatedLibrariesView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, deprecatedLibrariesRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, deprecatedLibrariesRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[DeprecatedLibrariesView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, deprecatedLibrariesRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, deprecatedLibrariesRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/DoesNonstandardPatternControllerSpec.scala
+++ b/test/controllers/DoesNonstandardPatternControllerSpec.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import forms.DoesNonstandardPatternFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.DoesNonstandardPatternPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.DoesNonstandardPatternView
+
+import scala.concurrent.Future
+
+class DoesNonstandardPatternControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new DoesNonstandardPatternFormProvider()
+  val form = formProvider()
+
+  lazy val doesNonstandardPatternRoute = routes.DoesNonstandardPatternController.onPageLoad(NormalMode).url
+
+  "DoesNonstandardPattern Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, doesNonstandardPatternRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[DoesNonstandardPatternView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(DoesNonstandardPatternPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, doesNonstandardPatternRoute)
+
+        val view = application.injector.instanceOf[DoesNonstandardPatternView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, doesNonstandardPatternRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, doesNonstandardPatternRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[DoesNonstandardPatternView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, doesNonstandardPatternRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, doesNonstandardPatternRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/ReadMeFitForPurposeControllerSpec.scala
+++ b/test/controllers/ReadMeFitForPurposeControllerSpec.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import forms.ReadMeFitForPurposeFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.ReadMeFitForPurposePage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.ReadMeFitForPurposeView
+
+import scala.concurrent.Future
+
+class ReadMeFitForPurposeControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new ReadMeFitForPurposeFormProvider()
+  val form = formProvider()
+
+  lazy val readMeFitForPurposeRoute = routes.ReadMeFitForPurposeController.onPageLoad(NormalMode).url
+
+  "ReadMeFitForPurpose Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, readMeFitForPurposeRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[ReadMeFitForPurposeView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(ReadMeFitForPurposePage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, readMeFitForPurposeRoute)
+
+        val view = application.injector.instanceOf[ReadMeFitForPurposeView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, readMeFitForPurposeRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, readMeFitForPurposeRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[ReadMeFitForPurposeView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, readMeFitForPurposeRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, readMeFitForPurposeRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/ServiceURLControllerSpec.scala
+++ b/test/controllers/ServiceURLControllerSpec.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import forms.ServiceURLFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.ServiceURLPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.ServiceURLView
+
+import scala.concurrent.Future
+
+class ServiceURLControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new ServiceURLFormProvider()
+  val form = formProvider()
+
+  lazy val serviceURLRoute = routes.ServiceURLController.onPageLoad(NormalMode).url
+
+  "ServiceURL Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, serviceURLRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[ServiceURLView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(ServiceURLPage, "answer").success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, serviceURLRoute)
+
+        val view = application.injector.instanceOf[ServiceURLView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill("answer"), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, serviceURLRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, serviceURLRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[ServiceURLView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, serviceURLRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, serviceURLRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/UsingHTTPVerbsControllerSpec.scala
+++ b/test/controllers/UsingHTTPVerbsControllerSpec.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import forms.UsingHTTPVerbsFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.UsingHTTPVerbsPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.UsingHTTPVerbsView
+
+import scala.concurrent.Future
+
+class UsingHTTPVerbsControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new UsingHTTPVerbsFormProvider()
+  val form = formProvider()
+
+  lazy val usingHTTPVerbsRoute = routes.UsingHTTPVerbsController.onPageLoad(NormalMode).url
+
+  "UsingHTTPVerbs Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, usingHTTPVerbsRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[UsingHTTPVerbsView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(UsingHTTPVerbsPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, usingHTTPVerbsRoute)
+
+        val view = application.injector.instanceOf[UsingHTTPVerbsView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, usingHTTPVerbsRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, usingHTTPVerbsRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[UsingHTTPVerbsView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, usingHTTPVerbsRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, usingHTTPVerbsRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/forms/DeprecatedLibrariesFormProviderSpec.scala
+++ b/test/forms/DeprecatedLibrariesFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class DeprecatedLibrariesFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "deprecatedLibraries.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new DeprecatedLibrariesFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/DoesNonstandardPatternFormProviderSpec.scala
+++ b/test/forms/DoesNonstandardPatternFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class DoesNonstandardPatternFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "doesNonstandardPattern.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new DoesNonstandardPatternFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/ReadMeFitForPurposeFormProviderSpec.scala
+++ b/test/forms/ReadMeFitForPurposeFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class ReadMeFitForPurposeFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "readMeFitForPurpose.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new ReadMeFitForPurposeFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/ServiceURLFormProviderSpec.scala
+++ b/test/forms/ServiceURLFormProviderSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+
+class ServiceURLFormProviderSpec extends StringFieldBehaviours {
+
+  val requiredKey = "serviceURL.error.required"
+  val lengthKey = "serviceURL.error.length"
+  val maxLength = 100
+
+  val form = new ServiceURLFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      stringsWithMaxLength(maxLength)
+    )
+
+    behave like fieldWithMaxLength(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/UsingHTTPVerbsFormProviderSpec.scala
+++ b/test/forms/UsingHTTPVerbsFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class UsingHTTPVerbsFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "usingHTTPVerbs.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new UsingHTTPVerbsFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -30,16 +30,46 @@ class NavigatorSpec extends SpecBase {
     "in Normal mode" - {
 
       "must go from a page that doesn't exist in the route map to Index" in {
-
         case object UnknownPage extends Page
         navigator.nextPage(UnknownPage, NormalMode, UserAnswers("id")) mustBe routes.IndexController.onPageLoad()
       }
-      "must go from the Index page to the Non-standard Pattern page" in {
-        navigator.nextPage(IndexPage, NormalMode, UserAnswers("id")) mustBe routes.NonstandardPatternController.onPageLoad(NormalMode)
+
+      "must go from the Index page to the Does Include Non-standard Pattern page" in {
+        navigator.nextPage(IndexPage, NormalMode, UserAnswers("id")) mustBe routes.ServiceURLController.onPageLoad(NormalMode)
       }
-      "must go from the Non-standard Pattern page to the Bobby Rules page" in {
+
+      "must go from the Service URL page to the Does Include Non-standard Pattern page" in {
+        navigator.nextPage(ServiceURLPage, NormalMode, UserAnswers("id")) mustBe routes.DoesNonstandardPatternController.onPageLoad(NormalMode)
+      }
+
+      "must go from the Does Include Non-standard Pattern page to the Which Non-standard Pattern page WHEN answer is YES" in {
+        UserAnswers("id").set(DoesNonstandardPatternPage, true).foreach{userAnswers =>
+          navigator.nextPage(DoesNonstandardPatternPage, NormalMode, userAnswers) mustBe routes.NonstandardPatternController.onPageLoad(NormalMode)
+        }
+      }
+
+      "must go from the Does Include Non-standard Pattern Page to Break Bobby Rules page WHEN answer is NO" in {
+        UserAnswers("id").set(DoesNonstandardPatternPage, false).foreach{userAnswers =>
+          navigator.nextPage(DoesNonstandardPatternPage, NormalMode, userAnswers) mustBe routes.BreakBobbyRulesController.onPageLoad(NormalMode)
+        }
+      }
+
+      "must go from the Which Non-standard Pattern page to the Bobby Rules page" in {
         navigator.nextPage(NonstandardPatternPage, NormalMode, UserAnswers("id")) mustBe routes.BreakBobbyRulesController.onPageLoad(NormalMode)
       }
+
+      "must go from the Bobby Rules page to the Deprecated HMRC Libraries page" in {
+        navigator.nextPage(BreakBobbyRulesPage, NormalMode, UserAnswers("id")) mustBe routes.DeprecatedLibrariesController.onPageLoad(NormalMode)
+      }
+
+      "must go from the Deprecated HMRC Libraries page to the Using HTTP Verbs page" in {
+        navigator.nextPage(DeprecatedLibrariesPage, NormalMode, UserAnswers("id")) mustBe routes.UsingHTTPVerbsController.onPageLoad(NormalMode)
+      }
+
+      "must go from the HTTP Verbs page to the ReadME Up-To-Date and fit for purpose page" in {
+        navigator.nextPage(UsingHTTPVerbsPage, NormalMode, UserAnswers("id")) mustBe routes.ReadMeFitForPurposeController.onPageLoad(NormalMode)
+      }
+
     }
 
     "in Check mode" - {


### PR DESCRIPTION
Edited and amended service journey using the existing PRA as guidance, with additional question to supply the URL of the service in the MDTP Catalogue 

Journey as detailed below:

- `/` to `/service-url`
- `/service-url` to `/does-nonstandard-pattern`
- Conditional routing from `/does-nonstandard-pattern` to either `/which-nonstandard-pattern` or `/break-bobby-rules`
- `/which-nonstandard-pattern` to `/break-bobby-rules`
- `/break-bobby-rules` to `/deprecated-libraries`
- `/deprecated-libraries` to `/using-http-verbs`
- `/using-http-verbs` to `/read-me-fit-for-purpose`