### PR TITLE
Created pages for PRA section 2 A-H

### DIFF
--- a/app/controllers/CheckYourAnswersController.scala
+++ b/app/controllers/CheckYourAnswersController.scala
@@ -22,7 +22,7 @@ import pages.buildResilience.DoesNonstandardPatternPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import viewmodels.checkAnswers.*
+import viewmodels.checkAnswers.buildResilience.*
 import viewmodels.govuk.summarylist.*
 import views.html.CheckYourAnswersView
 

--- a/app/controllers/dataPersistence/CorrectRetentionPeriodController.scala
+++ b/app/controllers/dataPersistence/CorrectRetentionPeriodController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import controllers.actions.*
+import forms.dataPersistence.CorrectRetentionPeriodFormProvider
+import models.Mode
+import navigation.Navigator
+import pages.dataPersistence.CorrectRetentionPeriodPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.dataPersistence.CorrectRetentionPeriodView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class CorrectRetentionPeriodController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionService: SessionService,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: CorrectRetentionPeriodFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: CorrectRetentionPeriodView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(CorrectRetentionPeriodPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(CorrectRetentionPeriodPage, value))
+            _              <- sessionService.setUserAnswers(updatedAnswers)
+          } yield Redirect(navigator.nextPage(CorrectRetentionPeriodPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/dataPersistence/FieldLevelEncryptionController.scala
+++ b/app/controllers/dataPersistence/FieldLevelEncryptionController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import controllers.actions.*
+import forms.dataPersistence.FieldLevelEncryptionFormProvider
+import models.Mode
+import navigation.Navigator
+import pages.dataPersistence.FieldLevelEncryptionPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.dataPersistence.FieldLevelEncryptionView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class FieldLevelEncryptionController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionService: SessionService,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: FieldLevelEncryptionFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: FieldLevelEncryptionView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(FieldLevelEncryptionPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(FieldLevelEncryptionPage, value))
+            _              <- sessionService.setUserAnswers(updatedAnswers)
+          } yield Redirect(navigator.nextPage(FieldLevelEncryptionPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/dataPersistence/MongoTestedWithIndexingController.scala
+++ b/app/controllers/dataPersistence/MongoTestedWithIndexingController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import controllers.actions.*
+import forms.dataPersistence.MongoTestedWithIndexingFormProvider
+import models.Mode
+import navigation.Navigator
+import pages.dataPersistence.MongoTestedWithIndexingPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.dataPersistence.MongoTestedWithIndexingView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class MongoTestedWithIndexingController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionService: SessionService,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: MongoTestedWithIndexingFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: MongoTestedWithIndexingView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(MongoTestedWithIndexingPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(MongoTestedWithIndexingPage, value))
+            _              <- sessionService.setUserAnswers(updatedAnswers)
+          } yield Redirect(navigator.nextPage(MongoTestedWithIndexingPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/dataPersistence/ProtectedMongoTTLController.scala
+++ b/app/controllers/dataPersistence/ProtectedMongoTTLController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import controllers.actions.*
+import forms.dataPersistence.ProtectedMongoTTLFormProvider
+import models.Mode
+import navigation.Navigator
+import pages.dataPersistence.ProtectedMongoTTLPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.dataPersistence.ProtectedMongoTTLView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class ProtectedMongoTTLController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionService: SessionService,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: ProtectedMongoTTLFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: ProtectedMongoTTLView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(ProtectedMongoTTLPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(ProtectedMongoTTLPage, value))
+            _              <- sessionService.setUserAnswers(updatedAnswers)
+          } yield Redirect(navigator.nextPage(ProtectedMongoTTLPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/dataPersistence/PublicMongoTTLController.scala
+++ b/app/controllers/dataPersistence/PublicMongoTTLController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import controllers.actions.*
+import forms.dataPersistence.PublicMongoTTLFormProvider
+import models.Mode
+import navigation.Navigator
+import pages.dataPersistence.PublicMongoTTLPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.dataPersistence.PublicMongoTTLView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class PublicMongoTTLController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionService: SessionService,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: PublicMongoTTLFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: PublicMongoTTLView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(PublicMongoTTLPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(PublicMongoTTLPage, value))
+            _              <- sessionService.setUserAnswers(updatedAnswers)
+          } yield Redirect(navigator.nextPage(PublicMongoTTLPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/dataPersistence/ResilientRecycleMongoController.scala
+++ b/app/controllers/dataPersistence/ResilientRecycleMongoController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import controllers.actions.*
+import forms.dataPersistence.ResilientRecycleMongoFormProvider
+import models.Mode
+import navigation.Navigator
+import pages.dataPersistence.ResilientRecycleMongoPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.dataPersistence.ResilientRecycleMongoView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class ResilientRecycleMongoController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionService: SessionService,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: ResilientRecycleMongoFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: ResilientRecycleMongoView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(ResilientRecycleMongoPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(ResilientRecycleMongoPage, value))
+            _              <- sessionService.setUserAnswers(updatedAnswers)
+          } yield Redirect(navigator.nextPage(ResilientRecycleMongoPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/dataPersistence/UsingMongoController.scala
+++ b/app/controllers/dataPersistence/UsingMongoController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import controllers.actions.*
+import forms.dataPersistence.UsingMongoFormProvider
+import models.Mode
+import navigation.Navigator
+import pages.dataPersistence.UsingMongoPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.dataPersistence.UsingMongoView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class UsingMongoController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionService: SessionService,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: UsingMongoFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: UsingMongoView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(UsingMongoPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(UsingMongoPage, value))
+            _              <- sessionService.setUserAnswers(updatedAnswers)
+          } yield Redirect(navigator.nextPage(UsingMongoPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/dataPersistence/UsingObjectStoreController.scala
+++ b/app/controllers/dataPersistence/UsingObjectStoreController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import controllers.actions.*
+import forms.dataPersistence.UsingObjectStoreFormProvider
+import models.Mode
+import navigation.Navigator
+import pages.dataPersistence.UsingObjectStorePage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.dataPersistence.UsingObjectStoreView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class UsingObjectStoreController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionService: SessionService,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: UsingObjectStoreFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: UsingObjectStoreView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(UsingObjectStorePage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(UsingObjectStorePage, value))
+            _              <- sessionService.setUserAnswers(updatedAnswers)
+          } yield Redirect(navigator.nextPage(UsingObjectStorePage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/forms/dataPersistence/CorrectRetentionPeriodFormProvider.scala
+++ b/app/forms/dataPersistence/CorrectRetentionPeriodFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+import javax.inject.Inject
+
+class CorrectRetentionPeriodFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("correctRetentionPeriod.error.required")
+    )
+}

--- a/app/forms/dataPersistence/FieldLevelEncryptionFormProvider.scala
+++ b/app/forms/dataPersistence/FieldLevelEncryptionFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+import javax.inject.Inject
+
+class FieldLevelEncryptionFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("fieldLevelEncryption.error.required")
+    )
+}

--- a/app/forms/dataPersistence/MongoTestedWithIndexingFormProvider.scala
+++ b/app/forms/dataPersistence/MongoTestedWithIndexingFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+import javax.inject.Inject
+
+class MongoTestedWithIndexingFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("mongoTestedWithIndexing.error.required")
+    )
+}

--- a/app/forms/dataPersistence/ProtectedMongoTTLFormProvider.scala
+++ b/app/forms/dataPersistence/ProtectedMongoTTLFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+import javax.inject.Inject
+
+class ProtectedMongoTTLFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("protectedMongoTTL.error.required")
+    )
+}

--- a/app/forms/dataPersistence/PublicMongoTTLFormProvider.scala
+++ b/app/forms/dataPersistence/PublicMongoTTLFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+import javax.inject.Inject
+
+class PublicMongoTTLFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("publicMongoTTL.error.required")
+    )
+}

--- a/app/forms/dataPersistence/ResilientRecycleMongoFormProvider.scala
+++ b/app/forms/dataPersistence/ResilientRecycleMongoFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+import javax.inject.Inject
+
+class ResilientRecycleMongoFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("resilientRecycleMongo.error.required")
+    )
+}

--- a/app/forms/dataPersistence/UsingMongoFormProvider.scala
+++ b/app/forms/dataPersistence/UsingMongoFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+import javax.inject.Inject
+
+class UsingMongoFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("usingMongo.error.required")
+    )
+}

--- a/app/forms/dataPersistence/UsingObjectStoreFormProvider.scala
+++ b/app/forms/dataPersistence/UsingObjectStoreFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+import javax.inject.Inject
+
+class UsingObjectStoreFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("usingObjectStore.error.required")
+    )
+}

--- a/app/pages/dataPersistence/CorrectRetentionPeriodPage.scala
+++ b/app/pages/dataPersistence/CorrectRetentionPeriodPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.dataPersistence
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object CorrectRetentionPeriodPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "correctRetentionPeriod"
+}

--- a/app/pages/dataPersistence/FieldLevelEncryptionPage.scala
+++ b/app/pages/dataPersistence/FieldLevelEncryptionPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.dataPersistence
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object FieldLevelEncryptionPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "fieldLevelEncryption"
+}

--- a/app/pages/dataPersistence/MongoTestedWithIndexingPage.scala
+++ b/app/pages/dataPersistence/MongoTestedWithIndexingPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.dataPersistence
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object MongoTestedWithIndexingPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "mongoTestedWithIndexing"
+}

--- a/app/pages/dataPersistence/ProtectedMongoTTLPage.scala
+++ b/app/pages/dataPersistence/ProtectedMongoTTLPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.dataPersistence
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object ProtectedMongoTTLPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "protectedMongoTTL"
+}

--- a/app/pages/dataPersistence/PublicMongoTTLPage.scala
+++ b/app/pages/dataPersistence/PublicMongoTTLPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.dataPersistence
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object PublicMongoTTLPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "publicMongoTTL"
+}

--- a/app/pages/dataPersistence/ResilientRecycleMongoPage.scala
+++ b/app/pages/dataPersistence/ResilientRecycleMongoPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.dataPersistence
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object ResilientRecycleMongoPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "resilientRecycleMongo"
+}

--- a/app/pages/dataPersistence/UsingMongoPage.scala
+++ b/app/pages/dataPersistence/UsingMongoPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.dataPersistence
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object UsingMongoPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "usingMongo"
+}

--- a/app/pages/dataPersistence/UsingObjectStorePage.scala
+++ b/app/pages/dataPersistence/UsingObjectStorePage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.dataPersistence
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object UsingObjectStorePage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "usingObjectStore"
+}

--- a/app/viewmodels/checkAnswers/buildResilience/AppropriateTimeoutsSummary.scala
+++ b/app/viewmodels/checkAnswers/buildResilience/AppropriateTimeoutsSummary.scala
@@ -14,30 +14,30 @@
  * limitations under the License.
  */
 
-package viewmodels.checkAnswers
+package viewmodels.checkAnswers.buildResilience
 
 import controllers.buildResilience.routes
 import models.{CheckMode, UserAnswers}
-import pages.buildResilience.DeprecatedLibrariesPage
+import pages.buildResilience.AppropriateTimeoutsPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist.*
 import viewmodels.implicits.*
 
-object DeprecatedLibrariesSummary  {
+object AppropriateTimeoutsSummary  {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
-    answers.get(DeprecatedLibrariesPage).map {
+    answers.get(AppropriateTimeoutsPage).map {
       answer =>
 
         val value = if (answer) "site.yes" else "site.no"
 
         SummaryListRowViewModel(
-          key     = "deprecatedLibraries.checkYourAnswersLabel",
+          key     = "appropriateTimeouts.checkYourAnswersLabel",
           value   = ValueViewModel(value),
           actions = Seq(
-            ActionItemViewModel("site.change", routes.DeprecatedLibrariesController.onPageLoad(CheckMode).url)
-              .withVisuallyHiddenText(messages("deprecatedLibraries.change.hidden"))
+            ActionItemViewModel("site.change", routes.AppropriateTimeoutsController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("appropriateTimeouts.change.hidden"))
           )
         )
     }

--- a/app/viewmodels/checkAnswers/buildResilience/BreakBobbyRulesSummary.scala
+++ b/app/viewmodels/checkAnswers/buildResilience/BreakBobbyRulesSummary.scala
@@ -14,30 +14,30 @@
  * limitations under the License.
  */
 
-package viewmodels.checkAnswers
+package viewmodels.checkAnswers.buildResilience
 
 import controllers.buildResilience.routes
 import models.{CheckMode, UserAnswers}
-import pages.buildResilience.ReadMeFitForPurposePage
+import pages.buildResilience.BreakBobbyRulesPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist.*
 import viewmodels.implicits.*
 
-object ReadMeFitForPurposeSummary  {
+object BreakBobbyRulesSummary  {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
-    answers.get(ReadMeFitForPurposePage).map {
+    answers.get(BreakBobbyRulesPage).map {
       answer =>
 
         val value = if (answer) "site.yes" else "site.no"
 
         SummaryListRowViewModel(
-          key     = "readMeFitForPurpose.checkYourAnswersLabel",
+          key     = "breakBobbyRules.checkYourAnswersLabel",
           value   = ValueViewModel(value),
           actions = Seq(
-            ActionItemViewModel("site.change", routes.ReadMeFitForPurposeController.onPageLoad(CheckMode).url)
-              .withVisuallyHiddenText(messages("readMeFitForPurpose.change.hidden"))
+            ActionItemViewModel("site.change", routes.BreakBobbyRulesController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("breakBobbyRules.change.hidden"))
           )
         )
     }

--- a/app/viewmodels/checkAnswers/buildResilience/DeprecatedLibrariesSummary.scala
+++ b/app/viewmodels/checkAnswers/buildResilience/DeprecatedLibrariesSummary.scala
@@ -14,30 +14,30 @@
  * limitations under the License.
  */
 
-package viewmodels.checkAnswers
+package viewmodels.checkAnswers.buildResilience
 
 import controllers.buildResilience.routes
 import models.{CheckMode, UserAnswers}
-import pages.buildResilience.DoesNonstandardPatternPage
+import pages.buildResilience.DeprecatedLibrariesPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist.*
 import viewmodels.implicits.*
 
-object DoesNonstandardPatternSummary  {
+object DeprecatedLibrariesSummary  {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
-    answers.get(DoesNonstandardPatternPage).map {
+    answers.get(DeprecatedLibrariesPage).map {
       answer =>
 
         val value = if (answer) "site.yes" else "site.no"
 
         SummaryListRowViewModel(
-          key     = "doesNonstandardPattern.checkYourAnswersLabel",
+          key     = "deprecatedLibraries.checkYourAnswersLabel",
           value   = ValueViewModel(value),
           actions = Seq(
-            ActionItemViewModel("site.change", routes.DoesNonstandardPatternController.onPageLoad(CheckMode).url)
-              .withVisuallyHiddenText(messages("doesNonstandardPattern.change.hidden"))
+            ActionItemViewModel("site.change", routes.DeprecatedLibrariesController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("deprecatedLibraries.change.hidden"))
           )
         )
     }

--- a/app/viewmodels/checkAnswers/buildResilience/DoesNonstandardPatternSummary.scala
+++ b/app/viewmodels/checkAnswers/buildResilience/DoesNonstandardPatternSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.buildResilience
+
+import controllers.buildResilience.routes
+import models.{CheckMode, UserAnswers}
+import pages.buildResilience.DoesNonstandardPatternPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist.*
+import viewmodels.implicits.*
+
+object DoesNonstandardPatternSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(DoesNonstandardPatternPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "doesNonstandardPattern.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.DoesNonstandardPatternController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("doesNonstandardPattern.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/buildResilience/NonstandardPatternSummary.scala
+++ b/app/viewmodels/checkAnswers/buildResilience/NonstandardPatternSummary.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.buildResilience
+
+import controllers.buildResilience.routes
+import models.{CheckMode, UserAnswers}
+import pages.buildResilience.NonstandardPatternPage
+import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist.*
+import viewmodels.implicits.*
+
+object NonstandardPatternSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(NonstandardPatternPage).map {
+      answer =>
+
+        SummaryListRowViewModel(
+          key     = "nonstandardPattern.checkYourAnswersLabel",
+          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.NonstandardPatternController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("nonstandardPattern.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/buildResilience/ReadMeFitForPurposeSummary.scala
+++ b/app/viewmodels/checkAnswers/buildResilience/ReadMeFitForPurposeSummary.scala
@@ -14,30 +14,30 @@
  * limitations under the License.
  */
 
-package viewmodels.checkAnswers
+package viewmodels.checkAnswers.buildResilience
 
 import controllers.buildResilience.routes
 import models.{CheckMode, UserAnswers}
-import pages.buildResilience.BreakBobbyRulesPage
+import pages.buildResilience.ReadMeFitForPurposePage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist.*
 import viewmodels.implicits.*
 
-object BreakBobbyRulesSummary  {
+object ReadMeFitForPurposeSummary  {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
-    answers.get(BreakBobbyRulesPage).map {
+    answers.get(ReadMeFitForPurposePage).map {
       answer =>
 
         val value = if (answer) "site.yes" else "site.no"
 
         SummaryListRowViewModel(
-          key     = "breakBobbyRules.checkYourAnswersLabel",
+          key     = "readMeFitForPurpose.checkYourAnswersLabel",
           value   = ValueViewModel(value),
           actions = Seq(
-            ActionItemViewModel("site.change", routes.BreakBobbyRulesController.onPageLoad(CheckMode).url)
-              .withVisuallyHiddenText(messages("breakBobbyRules.change.hidden"))
+            ActionItemViewModel("site.change", routes.ReadMeFitForPurposeController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("readMeFitForPurpose.change.hidden"))
           )
         )
     }

--- a/app/viewmodels/checkAnswers/buildResilience/ServiceURLSummary.scala
+++ b/app/viewmodels/checkAnswers/buildResilience/ServiceURLSummary.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.buildResilience
+
+import controllers.buildResilience.routes
+import models.{CheckMode, UserAnswers}
+import pages.buildResilience.ServiceURLPage
+import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist.*
+import viewmodels.implicits.*
+
+object ServiceURLSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(ServiceURLPage).map {
+      answer =>
+
+        SummaryListRowViewModel(
+          key     = "serviceURL.checkYourAnswersLabel",
+          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.ServiceURLController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("serviceURL.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/buildResilience/UsingHTTPVerbsSummary.scala
+++ b/app/viewmodels/checkAnswers/buildResilience/UsingHTTPVerbsSummary.scala
@@ -14,30 +14,30 @@
  * limitations under the License.
  */
 
-package viewmodels.checkAnswers
+package viewmodels.checkAnswers.buildResilience
 
 import controllers.buildResilience.routes
 import models.{CheckMode, UserAnswers}
-import pages.buildResilience.AppropriateTimeoutsPage
+import pages.buildResilience.UsingHTTPVerbsPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist.*
 import viewmodels.implicits.*
 
-object AppropriateTimeoutsSummary  {
+object UsingHTTPVerbsSummary  {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
-    answers.get(AppropriateTimeoutsPage).map {
+    answers.get(UsingHTTPVerbsPage).map {
       answer =>
 
         val value = if (answer) "site.yes" else "site.no"
 
         SummaryListRowViewModel(
-          key     = "appropriateTimeouts.checkYourAnswersLabel",
+          key     = "usingHTTPVerbs.checkYourAnswersLabel",
           value   = ValueViewModel(value),
           actions = Seq(
-            ActionItemViewModel("site.change", routes.AppropriateTimeoutsController.onPageLoad(CheckMode).url)
-              .withVisuallyHiddenText(messages("appropriateTimeouts.change.hidden"))
+            ActionItemViewModel("site.change", routes.UsingHTTPVerbsController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("usingHTTPVerbs.change.hidden"))
           )
         )
     }

--- a/app/viewmodels/checkAnswers/dataPersistence/CorrectRetentionPeriodSummary.scala
+++ b/app/viewmodels/checkAnswers/dataPersistence/CorrectRetentionPeriodSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.dataPersistence
+
+import controllers.dataPersistence.routes
+import models.{CheckMode, UserAnswers}
+import pages.dataPersistence.CorrectRetentionPeriodPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist.*
+import viewmodels.implicits.*
+
+object CorrectRetentionPeriodSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(CorrectRetentionPeriodPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "correctRetentionPeriod.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.CorrectRetentionPeriodController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("correctRetentionPeriod.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/dataPersistence/FieldLevelEncryptionSummary.scala
+++ b/app/viewmodels/checkAnswers/dataPersistence/FieldLevelEncryptionSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.dataPersistence
+
+import controllers.dataPersistence.routes
+import models.{CheckMode, UserAnswers}
+import pages.dataPersistence.FieldLevelEncryptionPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist.*
+import viewmodels.implicits.*
+
+object FieldLevelEncryptionSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(FieldLevelEncryptionPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "fieldLevelEncryption.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.FieldLevelEncryptionController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("fieldLevelEncryption.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/dataPersistence/MongoTestedWithIndexingSummary.scala
+++ b/app/viewmodels/checkAnswers/dataPersistence/MongoTestedWithIndexingSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.dataPersistence
+
+import controllers.dataPersistence.routes
+import models.{CheckMode, UserAnswers}
+import pages.dataPersistence.MongoTestedWithIndexingPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist.*
+import viewmodels.implicits.*
+
+object MongoTestedWithIndexingSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(MongoTestedWithIndexingPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "mongoTestedWithIndexing.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.MongoTestedWithIndexingController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("mongoTestedWithIndexing.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/dataPersistence/ProtectedMongoTTLSummary.scala
+++ b/app/viewmodels/checkAnswers/dataPersistence/ProtectedMongoTTLSummary.scala
@@ -14,29 +14,30 @@
  * limitations under the License.
  */
 
-package viewmodels.checkAnswers
+package viewmodels.checkAnswers.dataPersistence
 
-import controllers.buildResilience.routes
+import controllers.dataPersistence.routes
 import models.{CheckMode, UserAnswers}
-import pages.buildResilience.ServiceURLPage
+import pages.dataPersistence.ProtectedMongoTTLPage
 import play.api.i18n.Messages
-import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist.*
 import viewmodels.implicits.*
 
-object ServiceURLSummary  {
+object ProtectedMongoTTLSummary  {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
-    answers.get(ServiceURLPage).map {
+    answers.get(ProtectedMongoTTLPage).map {
       answer =>
 
+        val value = if (answer) "site.yes" else "site.no"
+
         SummaryListRowViewModel(
-          key     = "serviceURL.checkYourAnswersLabel",
-          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          key     = "protectedMongoTTL.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
           actions = Seq(
-            ActionItemViewModel("site.change", routes.ServiceURLController.onPageLoad(CheckMode).url)
-              .withVisuallyHiddenText(messages("serviceURL.change.hidden"))
+            ActionItemViewModel("site.change", routes.ProtectedMongoTTLController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("protectedMongoTTL.change.hidden"))
           )
         )
     }

--- a/app/viewmodels/checkAnswers/dataPersistence/PublicMongoTTLSummary.scala
+++ b/app/viewmodels/checkAnswers/dataPersistence/PublicMongoTTLSummary.scala
@@ -14,29 +14,30 @@
  * limitations under the License.
  */
 
-package viewmodels.checkAnswers
+package viewmodels.checkAnswers.dataPersistence
 
-import controllers.buildResilience.routes
+import controllers.dataPersistence.routes
 import models.{CheckMode, UserAnswers}
-import pages.buildResilience.NonstandardPatternPage
+import pages.dataPersistence.PublicMongoTTLPage
 import play.api.i18n.Messages
-import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist.*
 import viewmodels.implicits.*
 
-object NonstandardPatternSummary  {
+object PublicMongoTTLSummary  {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
-    answers.get(NonstandardPatternPage).map {
+    answers.get(PublicMongoTTLPage).map {
       answer =>
 
+        val value = if (answer) "site.yes" else "site.no"
+
         SummaryListRowViewModel(
-          key     = "nonstandardPattern.checkYourAnswersLabel",
-          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          key     = "publicMongoTTL.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
           actions = Seq(
-            ActionItemViewModel("site.change", routes.NonstandardPatternController.onPageLoad(CheckMode).url)
-              .withVisuallyHiddenText(messages("nonstandardPattern.change.hidden"))
+            ActionItemViewModel("site.change", routes.PublicMongoTTLController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("publicMongoTTL.change.hidden"))
           )
         )
     }

--- a/app/viewmodels/checkAnswers/dataPersistence/ResilientRecycleMongoSummary.scala
+++ b/app/viewmodels/checkAnswers/dataPersistence/ResilientRecycleMongoSummary.scala
@@ -14,30 +14,30 @@
  * limitations under the License.
  */
 
-package viewmodels.checkAnswers
+package viewmodels.checkAnswers.dataPersistence
 
-import controllers.buildResilience.routes
+import controllers.dataPersistence.routes
 import models.{CheckMode, UserAnswers}
-import pages.buildResilience.UsingHTTPVerbsPage
+import pages.dataPersistence.ResilientRecycleMongoPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist.*
 import viewmodels.implicits.*
 
-object UsingHTTPVerbsSummary  {
+object ResilientRecycleMongoSummary  {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
-    answers.get(UsingHTTPVerbsPage).map {
+    answers.get(ResilientRecycleMongoPage).map {
       answer =>
 
         val value = if (answer) "site.yes" else "site.no"
 
         SummaryListRowViewModel(
-          key     = "usingHTTPVerbs.checkYourAnswersLabel",
+          key     = "resilientRecycleMongo.checkYourAnswersLabel",
           value   = ValueViewModel(value),
           actions = Seq(
-            ActionItemViewModel("site.change", routes.UsingHTTPVerbsController.onPageLoad(CheckMode).url)
-              .withVisuallyHiddenText(messages("usingHTTPVerbs.change.hidden"))
+            ActionItemViewModel("site.change", routes.ResilientRecycleMongoController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("resilientRecycleMongo.change.hidden"))
           )
         )
     }

--- a/app/viewmodels/checkAnswers/dataPersistence/UsingMongoSummary.scala
+++ b/app/viewmodels/checkAnswers/dataPersistence/UsingMongoSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.dataPersistence
+
+import controllers.dataPersistence.routes
+import models.{CheckMode, UserAnswers}
+import pages.dataPersistence.UsingMongoPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist.*
+import viewmodels.implicits.*
+
+object UsingMongoSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(UsingMongoPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "usingMongo.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.UsingMongoController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("usingMongo.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/dataPersistence/UsingObjectStoreSummary.scala
+++ b/app/viewmodels/checkAnswers/dataPersistence/UsingObjectStoreSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.dataPersistence
+
+import controllers.dataPersistence.routes
+import models.{CheckMode, UserAnswers}
+import pages.dataPersistence.UsingObjectStorePage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist.*
+import viewmodels.implicits.*
+
+object UsingObjectStoreSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(UsingObjectStorePage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "usingObjectStore.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.UsingObjectStoreController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("usingObjectStore.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/views/dataPersistence/CorrectRetentionPeriodView.scala.html
+++ b/app/views/dataPersistence/CorrectRetentionPeriodView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("correctRetentionPeriod.title"))) {
+
+    @formHelper(action = controllers.dataPersistence.routes.CorrectRetentionPeriodController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("correctRetentionPeriod.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/dataPersistence/FieldLevelEncryptionView.scala.html
+++ b/app/views/dataPersistence/FieldLevelEncryptionView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("fieldLevelEncryption.title"))) {
+
+    @formHelper(action = controllers.dataPersistence.routes.FieldLevelEncryptionController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("fieldLevelEncryption.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/dataPersistence/MongoTestedWithIndexingView.scala.html
+++ b/app/views/dataPersistence/MongoTestedWithIndexingView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("mongoTestedWithIndexing.title"))) {
+
+    @formHelper(action = controllers.dataPersistence.routes.MongoTestedWithIndexingController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("mongoTestedWithIndexing.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/dataPersistence/ProtectedMongoTTLView.scala.html
+++ b/app/views/dataPersistence/ProtectedMongoTTLView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("protectedMongoTTL.title"))) {
+
+    @formHelper(action = controllers.dataPersistence.routes.ProtectedMongoTTLController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("protectedMongoTTL.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/dataPersistence/PublicMongoTTLView.scala.html
+++ b/app/views/dataPersistence/PublicMongoTTLView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("publicMongoTTL.title"))) {
+
+    @formHelper(action = controllers.dataPersistence.routes.PublicMongoTTLController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("publicMongoTTL.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/dataPersistence/ResilientRecycleMongoView.scala.html
+++ b/app/views/dataPersistence/ResilientRecycleMongoView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("resilientRecycleMongo.title"))) {
+
+    @formHelper(action = controllers.dataPersistence.routes.ResilientRecycleMongoController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("resilientRecycleMongo.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/dataPersistence/UsingMongoView.scala.html
+++ b/app/views/dataPersistence/UsingMongoView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("usingMongo.title"))) {
+
+    @formHelper(action = controllers.dataPersistence.routes.UsingMongoController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("usingMongo.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/dataPersistence/UsingObjectStoreView.scala.html
+++ b/app/views/dataPersistence/UsingObjectStoreView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("usingObjectStore.title"))) {
+
+    @formHelper(action = controllers.dataPersistence.routes.UsingObjectStoreController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("usingObjectStore.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -4,6 +4,8 @@
 
 ->          /build-resilience                            buildResilience.Routes
 
+->          /data-persistence                            dataPersistence.Routes
+
 GET         /                                            controllers.IndexController.onPageLoad()
 
 GET         /assets/*file                                controllers.Assets.versioned(path="/public", file: Asset)

--- a/conf/dataPersistence.routes
+++ b/conf/dataPersistence.routes
@@ -1,0 +1,39 @@
+GET         /using-mongo                                 controllers.dataPersistence.UsingMongoController.onPageLoad(mode: Mode = NormalMode)
+POST        /using-mongo                                 controllers.dataPersistence.UsingMongoController.onSubmit(mode: Mode = NormalMode)
+GET         /change-using-mongo                          controllers.dataPersistence.UsingMongoController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-using-mongo                          controllers.dataPersistence.UsingMongoController.onSubmit(mode: Mode = CheckMode)
+
+GET         /resilient-recycle-mongo                     controllers.dataPersistence.ResilientRecycleMongoController.onPageLoad(mode: Mode = NormalMode)
+POST        /resilient-recycle-mongo                     controllers.dataPersistence.ResilientRecycleMongoController.onSubmit(mode: Mode = NormalMode)
+GET         /change-resilient-recycle-mongo              controllers.dataPersistence.ResilientRecycleMongoController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-resilient-recycle-mongo              controllers.dataPersistence.ResilientRecycleMongoController.onSubmit(mode: Mode = CheckMode)
+
+GET         /public-mongo-ttl                            controllers.dataPersistence.PublicMongoTTLController.onPageLoad(mode: Mode = NormalMode)
+POST        /public-mongo-ttl                            controllers.dataPersistence.PublicMongoTTLController.onSubmit(mode: Mode = NormalMode)
+GET         /change-public-mongo-ttl                     controllers.dataPersistence.PublicMongoTTLController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-public-mongo-ttl                     controllers.dataPersistence.PublicMongoTTLController.onSubmit(mode: Mode = CheckMode)
+
+GET         /field-level-encryption                      controllers.dataPersistence.FieldLevelEncryptionController.onPageLoad(mode: Mode = NormalMode)
+POST        /field-level-encryption                      controllers.dataPersistence.FieldLevelEncryptionController.onSubmit(mode: Mode = NormalMode)
+GET         /change-field-level-encryption               controllers.dataPersistence.FieldLevelEncryptionController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-field-level-encryption               controllers.dataPersistence.FieldLevelEncryptionController.onSubmit(mode: Mode = CheckMode)
+
+GET         /protected-mongo-ttl                         controllers.dataPersistence.ProtectedMongoTTLController.onPageLoad(mode: Mode = NormalMode)
+POST        /protected-mongo-ttl                         controllers.dataPersistence.ProtectedMongoTTLController.onSubmit(mode: Mode = NormalMode)
+GET         /change-protected-mongo-ttl                  controllers.dataPersistence.ProtectedMongoTTLController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-protected-mongo-ttl                  controllers.dataPersistence.ProtectedMongoTTLController.onSubmit(mode: Mode = CheckMode)
+
+GET         /mongo-tested-with-indexing                  controllers.dataPersistence.MongoTestedWithIndexingController.onPageLoad(mode: Mode = NormalMode)
+POST        /mongo-tested-with-indexing                  controllers.dataPersistence.MongoTestedWithIndexingController.onSubmit(mode: Mode = NormalMode)
+GET         /change-mongo-tested-with-indexing           controllers.dataPersistence.MongoTestedWithIndexingController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-mongo-tested-with-indexing           controllers.dataPersistence.MongoTestedWithIndexingController.onSubmit(mode: Mode = CheckMode)
+
+GET         /using-object-store                          controllers.dataPersistence.UsingObjectStoreController.onPageLoad(mode: Mode = NormalMode)
+POST        /using-object-store                          controllers.dataPersistence.UsingObjectStoreController.onSubmit(mode: Mode = NormalMode)
+GET         /change-using-object-store                   controllers.dataPersistence.UsingObjectStoreController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-using-object-store                   controllers.dataPersistence.UsingObjectStoreController.onSubmit(mode: Mode = CheckMode)
+
+GET         /correct-retention-period                    controllers.dataPersistence.CorrectRetentionPeriodController.onPageLoad(mode: Mode = NormalMode)
+POST        /correct-retention-period                    controllers.dataPersistence.CorrectRetentionPeriodController.onSubmit(mode: Mode = NormalMode)
+GET         /change-correct-retention-period             controllers.dataPersistence.CorrectRetentionPeriodController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-correct-retention-period             controllers.dataPersistence.CorrectRetentionPeriodController.onSubmit(mode: Mode = CheckMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -54,6 +54,10 @@ signedOut.guidance = We did not save your answers.
 unauthorised.title = You can’t access this service with this account
 unauthorised.heading = You can’t access this service with this account
 
+#========================================
+#          Build & Resilience
+#========================================
+
 serviceURL.title = What is the service page URL for your service within the MDTP Catalogue?
 serviceURL.heading = What is the service page URL for your service within the MDTP Catalogue?
 serviceURL.checkYourAnswersLabel = MDTP Catalogue Service URL
@@ -109,3 +113,55 @@ appropriateTimeouts.hint = This should be proven through tests. Check the docume
 appropriateTimeouts.hintURL = MDTP Retries and Timeouts
 appropriateTimeouts.hint2 = If a downstream system starts to consistently fail your services should degrade gracefully, this should be proven with tests.
 appropriateTimeouts.hint3 = You should also confirm HoD API usage fits within the Scrubbing Centre rate limits.
+
+#========================================
+#           Data Persistence
+#========================================
+
+correctRetentionPeriod.title = correctRetentionPeriod
+correctRetentionPeriod.heading = correctRetentionPeriod
+correctRetentionPeriod.checkYourAnswersLabel = correctRetentionPeriod
+correctRetentionPeriod.error.required = Select yes if correctRetentionPeriod
+correctRetentionPeriod.change.hidden = CorrectRetentionPeriod
+
+fieldLevelEncryption.title = fieldLevelEncryption
+fieldLevelEncryption.heading = fieldLevelEncryption
+fieldLevelEncryption.checkYourAnswersLabel = fieldLevelEncryption
+fieldLevelEncryption.error.required = Select yes if fieldLevelEncryption
+fieldLevelEncryption.change.hidden = FieldLevelEncryption
+
+mongoTestedWithIndexing.title = mongoTestedWithIndexing
+mongoTestedWithIndexing.heading = mongoTestedWithIndexing
+mongoTestedWithIndexing.checkYourAnswersLabel = mongoTestedWithIndexing
+mongoTestedWithIndexing.error.required = Select yes if mongoTestedWithIndexing
+mongoTestedWithIndexing.change.hidden = MongoTestedWithIndexing
+
+protectedMongoTTL.title = protectedMongoTTL
+protectedMongoTTL.heading = protectedMongoTTL
+protectedMongoTTL.checkYourAnswersLabel = protectedMongoTTL
+protectedMongoTTL.error.required = Select yes if protectedMongoTTL
+protectedMongoTTL.change.hidden = ProtectedMongoTTL
+
+publicMongoTTL.title = publicMongoTTL
+publicMongoTTL.heading = publicMongoTTL
+publicMongoTTL.checkYourAnswersLabel = publicMongoTTL
+publicMongoTTL.error.required = Select yes if publicMongoTTL
+publicMongoTTL.change.hidden = PublicMongoTTL
+
+resilientRecycleMongo.title = resilientRecycleMongo
+resilientRecycleMongo.heading = resilientRecycleMongo
+resilientRecycleMongo.checkYourAnswersLabel = resilientRecycleMongo
+resilientRecycleMongo.error.required = Select yes if resilientRecycleMongo
+resilientRecycleMongo.change.hidden = ResilientRecycleMongo
+
+usingMongo.title = usingMongo
+usingMongo.heading = usingMongo
+usingMongo.checkYourAnswersLabel = usingMongo
+usingMongo.error.required = Select yes if usingMongo
+usingMongo.change.hidden = UsingMongo
+
+usingObjectStore.title = usingObjectStore
+usingObjectStore.heading = usingObjectStore
+usingObjectStore.checkYourAnswersLabel = usingObjectStore
+usingObjectStore.error.required = Select yes if usingObjectStore
+usingObjectStore.change.hidden = UsingObjectStore

--- a/test/controllers/dataPersistence/CorrectRetentionPeriodControllerSpec.scala
+++ b/test/controllers/dataPersistence/CorrectRetentionPeriodControllerSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import base.SpecBase
+import controllers.routes
+import controllers.dataPersistence.routes as dataRoutes
+import forms.dataPersistence.CorrectRetentionPeriodFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.dataPersistence.CorrectRetentionPeriodPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.mvc.Results.NoContent
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import services.SessionService
+import views.html.dataPersistence.CorrectRetentionPeriodView
+
+import scala.concurrent.Future
+
+class CorrectRetentionPeriodControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new CorrectRetentionPeriodFormProvider()
+  val form = formProvider()
+
+  lazy val correctRetentionPeriodRoute = dataRoutes.CorrectRetentionPeriodController.onPageLoad(NormalMode).url
+
+  "CorrectRetentionPeriod Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, correctRetentionPeriodRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[CorrectRetentionPeriodView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(CorrectRetentionPeriodPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, correctRetentionPeriodRoute)
+
+        val view = application.injector.instanceOf[CorrectRetentionPeriodView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionService = mock[SessionService]
+
+      when(mockSessionService.setUserAnswers(any())(any())) thenReturn Future.successful(NoContent)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionService].toInstance(mockSessionService)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, correctRetentionPeriodRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, correctRetentionPeriodRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[CorrectRetentionPeriodView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, correctRetentionPeriodRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, correctRetentionPeriodRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/dataPersistence/FieldLevelEncryptionControllerSpec.scala
+++ b/test/controllers/dataPersistence/FieldLevelEncryptionControllerSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import base.SpecBase
+import controllers.routes
+import controllers.dataPersistence.routes as dataRoutes
+import forms.dataPersistence.FieldLevelEncryptionFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.dataPersistence.FieldLevelEncryptionPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.mvc.Results.NoContent
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import services.SessionService
+import views.html.dataPersistence.FieldLevelEncryptionView
+
+import scala.concurrent.Future
+
+class FieldLevelEncryptionControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new FieldLevelEncryptionFormProvider()
+  val form = formProvider()
+
+  lazy val fieldLevelEncryptionRoute = dataRoutes.FieldLevelEncryptionController.onPageLoad(NormalMode).url
+
+  "FieldLevelEncryption Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, fieldLevelEncryptionRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[FieldLevelEncryptionView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(FieldLevelEncryptionPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, fieldLevelEncryptionRoute)
+
+        val view = application.injector.instanceOf[FieldLevelEncryptionView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionService = mock[SessionService]
+
+      when(mockSessionService.setUserAnswers(any())(any())) thenReturn Future.successful(NoContent)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionService].toInstance(mockSessionService)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, fieldLevelEncryptionRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, fieldLevelEncryptionRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[FieldLevelEncryptionView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, fieldLevelEncryptionRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, fieldLevelEncryptionRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/dataPersistence/MongoTestedWithIndexingControllerSpec.scala
+++ b/test/controllers/dataPersistence/MongoTestedWithIndexingControllerSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import base.SpecBase
+import controllers.routes
+import controllers.dataPersistence.routes as dataRoutes
+import forms.dataPersistence.MongoTestedWithIndexingFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.dataPersistence.MongoTestedWithIndexingPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.mvc.Results.NoContent
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import services.SessionService
+import views.html.dataPersistence.MongoTestedWithIndexingView
+
+import scala.concurrent.Future
+
+class MongoTestedWithIndexingControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new MongoTestedWithIndexingFormProvider()
+  val form = formProvider()
+
+  lazy val mongoTestedWithIndexingRoute = dataRoutes.MongoTestedWithIndexingController.onPageLoad(NormalMode).url
+
+  "MongoTestedWithIndexing Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, mongoTestedWithIndexingRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[MongoTestedWithIndexingView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(MongoTestedWithIndexingPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, mongoTestedWithIndexingRoute)
+
+        val view = application.injector.instanceOf[MongoTestedWithIndexingView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionService = mock[SessionService]
+
+      when(mockSessionService.setUserAnswers(any())(any())) thenReturn Future.successful(NoContent)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionService].toInstance(mockSessionService)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, mongoTestedWithIndexingRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, mongoTestedWithIndexingRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[MongoTestedWithIndexingView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, mongoTestedWithIndexingRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, mongoTestedWithIndexingRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/dataPersistence/ProtectedMongoTTLControllerSpec.scala
+++ b/test/controllers/dataPersistence/ProtectedMongoTTLControllerSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import base.SpecBase
+import controllers.routes
+import controllers.dataPersistence.routes as dataRoutes
+import forms.dataPersistence.ProtectedMongoTTLFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.dataPersistence.ProtectedMongoTTLPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.mvc.Results.NoContent
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import services.SessionService
+import views.html.dataPersistence.ProtectedMongoTTLView
+
+import scala.concurrent.Future
+
+class ProtectedMongoTTLControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new ProtectedMongoTTLFormProvider()
+  val form = formProvider()
+
+  lazy val protectedMongoTTLRoute = dataRoutes.ProtectedMongoTTLController.onPageLoad(NormalMode).url
+
+  "ProtectedMongoTTL Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, protectedMongoTTLRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[ProtectedMongoTTLView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(ProtectedMongoTTLPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, protectedMongoTTLRoute)
+
+        val view = application.injector.instanceOf[ProtectedMongoTTLView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionService = mock[SessionService]
+
+      when(mockSessionService.setUserAnswers(any())(any())) thenReturn Future.successful(NoContent)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionService].toInstance(mockSessionService)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, protectedMongoTTLRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, protectedMongoTTLRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[ProtectedMongoTTLView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, protectedMongoTTLRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, protectedMongoTTLRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/dataPersistence/PublicMongoTTLControllerSpec.scala
+++ b/test/controllers/dataPersistence/PublicMongoTTLControllerSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import base.SpecBase
+import controllers.routes
+import controllers.dataPersistence.routes as dataRoutes
+import forms.dataPersistence.PublicMongoTTLFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.dataPersistence.PublicMongoTTLPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.mvc.Results.NoContent
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import services.SessionService
+import views.html.dataPersistence.PublicMongoTTLView
+
+import scala.concurrent.Future
+
+class PublicMongoTTLControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new PublicMongoTTLFormProvider()
+  val form = formProvider()
+
+  lazy val publicMongoTTLRoute = dataRoutes.PublicMongoTTLController.onPageLoad(NormalMode).url
+
+  "PublicMongoTTL Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, publicMongoTTLRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[PublicMongoTTLView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(PublicMongoTTLPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, publicMongoTTLRoute)
+
+        val view = application.injector.instanceOf[PublicMongoTTLView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionService = mock[SessionService]
+
+      when(mockSessionService.setUserAnswers(any())(any())) thenReturn Future.successful(NoContent)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionService].toInstance(mockSessionService)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, publicMongoTTLRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, publicMongoTTLRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[PublicMongoTTLView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, publicMongoTTLRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, publicMongoTTLRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/dataPersistence/ResilientRecycleMongoControllerSpec.scala
+++ b/test/controllers/dataPersistence/ResilientRecycleMongoControllerSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import base.SpecBase
+import controllers.routes
+import controllers.dataPersistence.routes as dataRoutes
+import forms.dataPersistence.ResilientRecycleMongoFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.dataPersistence.ResilientRecycleMongoPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.mvc.Results.NoContent
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import services.SessionService
+import views.html.dataPersistence.ResilientRecycleMongoView
+
+import scala.concurrent.Future
+
+class ResilientRecycleMongoControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new ResilientRecycleMongoFormProvider()
+  val form = formProvider()
+
+  lazy val resilientRecycleMongoRoute = dataRoutes.ResilientRecycleMongoController.onPageLoad(NormalMode).url
+
+  "ResilientRecycleMongo Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, resilientRecycleMongoRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[ResilientRecycleMongoView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(ResilientRecycleMongoPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, resilientRecycleMongoRoute)
+
+        val view = application.injector.instanceOf[ResilientRecycleMongoView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionService = mock[SessionService]
+
+      when(mockSessionService.setUserAnswers(any())(any())) thenReturn Future.successful(NoContent)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionService].toInstance(mockSessionService)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, resilientRecycleMongoRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, resilientRecycleMongoRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[ResilientRecycleMongoView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, resilientRecycleMongoRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, resilientRecycleMongoRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/dataPersistence/UsingMongoControllerSpec.scala
+++ b/test/controllers/dataPersistence/UsingMongoControllerSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import base.SpecBase
+import controllers.routes
+import controllers.dataPersistence.routes as dataRoutes
+import forms.dataPersistence.UsingMongoFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.dataPersistence.UsingMongoPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.mvc.Results.NoContent
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import services.SessionService
+import views.html.dataPersistence.UsingMongoView
+
+import scala.concurrent.Future
+
+class UsingMongoControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new UsingMongoFormProvider()
+  val form = formProvider()
+
+  lazy val usingMongoRoute = dataRoutes.UsingMongoController.onPageLoad(NormalMode).url
+
+  "UsingMongo Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, usingMongoRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[UsingMongoView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(UsingMongoPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, usingMongoRoute)
+
+        val view = application.injector.instanceOf[UsingMongoView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionService = mock[SessionService]
+
+      when(mockSessionService.setUserAnswers(any())(any())) thenReturn Future.successful(NoContent)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionService].toInstance(mockSessionService)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, usingMongoRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, usingMongoRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[UsingMongoView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, usingMongoRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, usingMongoRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/dataPersistence/UsingObjectStoreControllerSpec.scala
+++ b/test/controllers/dataPersistence/UsingObjectStoreControllerSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.dataPersistence
+
+import base.SpecBase
+import controllers.routes
+import controllers.dataPersistence.routes as dataRoutes
+import forms.dataPersistence.UsingObjectStoreFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.dataPersistence.UsingObjectStorePage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.mvc.Results.NoContent
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import services.SessionService
+import views.html.dataPersistence.UsingObjectStoreView
+
+import scala.concurrent.Future
+
+class UsingObjectStoreControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new UsingObjectStoreFormProvider()
+  val form = formProvider()
+
+  lazy val usingObjectStoreRoute = dataRoutes.UsingObjectStoreController.onPageLoad(NormalMode).url
+
+  "UsingObjectStore Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, usingObjectStoreRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[UsingObjectStoreView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(UsingObjectStorePage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, usingObjectStoreRoute)
+
+        val view = application.injector.instanceOf[UsingObjectStoreView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionService = mock[SessionService]
+
+      when(mockSessionService.setUserAnswers(any())(any())) thenReturn Future.successful(NoContent)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionService].toInstance(mockSessionService)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, usingObjectStoreRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, usingObjectStoreRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[UsingObjectStoreView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, usingObjectStoreRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, usingObjectStoreRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/forms/dataPersistence/CorrectRetentionPeriodFormProviderSpec.scala
+++ b/test/forms/dataPersistence/CorrectRetentionPeriodFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class CorrectRetentionPeriodFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "correctRetentionPeriod.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new CorrectRetentionPeriodFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/dataPersistence/FieldLevelEncryptionFormProviderSpec.scala
+++ b/test/forms/dataPersistence/FieldLevelEncryptionFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class FieldLevelEncryptionFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "fieldLevelEncryption.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new FieldLevelEncryptionFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/dataPersistence/MongoTestedWithIndexingFormProviderSpec.scala
+++ b/test/forms/dataPersistence/MongoTestedWithIndexingFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class MongoTestedWithIndexingFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "mongoTestedWithIndexing.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new MongoTestedWithIndexingFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/dataPersistence/ProtectedMongoTTLFormProviderSpec.scala
+++ b/test/forms/dataPersistence/ProtectedMongoTTLFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class ProtectedMongoTTLFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "protectedMongoTTL.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new ProtectedMongoTTLFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/dataPersistence/PublicMongoTTLFormProviderSpec.scala
+++ b/test/forms/dataPersistence/PublicMongoTTLFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class PublicMongoTTLFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "publicMongoTTL.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new PublicMongoTTLFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/dataPersistence/ResilientRecycleMongoFormProviderSpec.scala
+++ b/test/forms/dataPersistence/ResilientRecycleMongoFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class ResilientRecycleMongoFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "resilientRecycleMongo.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new ResilientRecycleMongoFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/dataPersistence/UsingMongoFormProviderSpec.scala
+++ b/test/forms/dataPersistence/UsingMongoFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class UsingMongoFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "usingMongo.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new UsingMongoFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/dataPersistence/UsingObjectStoreFormProviderSpec.scala
+++ b/test/forms/dataPersistence/UsingObjectStoreFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.dataPersistence
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class UsingObjectStoreFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "usingObjectStore.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new UsingObjectStoreFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}


### PR DESCRIPTION
Created the following pages as a starting point for section 2 (covering 2A-H) of the PRA:

- `/using-mongo` 
- `/resilient-recycle-mongo`
- `/public-mongo-ttl`
- `/field-level-encryption`
- `/protected-mongo-ttl`
- `/mongo-tested-with-indexing`
- `/using-object-store`
- `/correct-retention-period`

All of these pages have been added into a `/dataPersistence` package to fall in line with [`/buildResilience` subdirectories PR](https://github.com/hmrc/platform-readiness-spike-frontend/pull/13)

None of these pages currently have a journey or relevant message keys