### PR TITLE
Added Journey for PRA section 2A-H

### DIFF
--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -17,10 +17,12 @@
 package navigation
 
 import controllers.buildResilience.routes as buildRoutes
+import controllers.dataPersistence.routes as dataRoutes
 import controllers.routes
 import models.*
 import pages.*
 import pages.buildResilience.{AppropriateTimeoutsPage, BreakBobbyRulesPage, DeprecatedLibrariesPage, DoesNonstandardPatternPage, NonstandardPatternPage, ReadMeFitForPurposePage, ServiceURLPage, UsingHTTPVerbsPage}
+import pages.dataPersistence.{CorrectRetentionPeriodPage, FieldLevelEncryptionPage, MongoTestedWithIndexingPage, ProtectedMongoTTLPage, PublicMongoTTLPage, ResilientRecycleMongoPage, UsingMongoPage, UsingObjectStorePage}
 import play.api.mvc.Call
 
 import javax.inject.{Inject, Singleton}
@@ -34,6 +36,7 @@ class Navigator @Inject()() {
                        BUILD & RESILIENCE
     
     #######################################################*/
+
     case IndexPage => _ => buildRoutes.ServiceURLController.onPageLoad(NormalMode)
 
     case ServiceURLPage => _ => buildRoutes.DoesNonstandardPatternController.onPageLoad(NormalMode)
@@ -55,6 +58,28 @@ class Navigator @Inject()() {
     case ReadMeFitForPurposePage => _ => buildRoutes.AppropriateTimeoutsController.onPageLoad(NormalMode)
 
     case AppropriateTimeoutsPage => _ => buildRoutes.CheckYourAnswersController.onPageLoad()
+
+    /*######################################################
+
+                      DATA PERSISTENCE
+
+    #######################################################*/
+
+    case UsingMongoPage => _ => dataRoutes.ResilientRecycleMongoController.onPageLoad(NormalMode)
+
+    case ResilientRecycleMongoPage => _ => dataRoutes.PublicMongoTTLController.onPageLoad(NormalMode)
+
+    case PublicMongoTTLPage => _ => dataRoutes.FieldLevelEncryptionController.onPageLoad(NormalMode)
+
+    case FieldLevelEncryptionPage => _ => dataRoutes.ProtectedMongoTTLController.onPageLoad(NormalMode)
+
+    case ProtectedMongoTTLPage => _ => dataRoutes.MongoTestedWithIndexingController.onPageLoad(NormalMode)
+
+    case MongoTestedWithIndexingPage => _ => dataRoutes.UsingObjectStoreController.onPageLoad(NormalMode)
+
+    case UsingObjectStorePage => _ => dataRoutes.CorrectRetentionPeriodController.onPageLoad(NormalMode)
+
+    case CorrectRetentionPeriodPage => _ => dataRoutes.CheckYourAnswersController.onPageLoad()
 
     case _ => _ => routes.IndexController.onPageLoad()
   }

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -19,9 +19,11 @@ package navigation
 import base.SpecBase
 import controllers.routes
 import controllers.buildResilience.routes as buildRoutes
+import controllers.dataPersistence.routes as dataRoutes
 import models.*
 import pages.*
 import pages.buildResilience.{AppropriateTimeoutsPage, BreakBobbyRulesPage, DeprecatedLibrariesPage, DoesNonstandardPatternPage, NonstandardPatternPage, ReadMeFitForPurposePage, ServiceURLPage, UsingHTTPVerbsPage}
+import pages.dataPersistence.{CorrectRetentionPeriodPage, FieldLevelEncryptionPage, MongoTestedWithIndexingPage, ProtectedMongoTTLPage, PublicMongoTTLPage, ResilientRecycleMongoPage, UsingMongoPage, UsingObjectStorePage}
 
 class NavigatorSpec extends SpecBase {
 
@@ -31,53 +33,85 @@ class NavigatorSpec extends SpecBase {
 
     "in Normal mode" - {
 
-      "must go from a page that doesn't exist in the route map to Index" in {
-        case object UnknownPage extends Page
-        navigator.nextPage(UnknownPage, NormalMode, UserAnswers("id")) mustBe routes.IndexController.onPageLoad()
-      }
+      "in Build & Resilience" - {
 
-      "must go from the Index page to the Does Include Non-standard Pattern page" in {
-        navigator.nextPage(IndexPage, NormalMode, UserAnswers("id")) mustBe buildRoutes.ServiceURLController.onPageLoad(NormalMode)
-      }
+        "must go from a page that doesn't exist in the route map to Index" in {
+          case object UnknownPage extends Page
+          navigator.nextPage(UnknownPage, NormalMode, UserAnswers("id")) mustBe routes.IndexController.onPageLoad()
+        }
 
-      "must go from the Service URL page to the Does Include Non-standard Pattern page" in {
-        navigator.nextPage(ServiceURLPage, NormalMode, UserAnswers("id")) mustBe buildRoutes.DoesNonstandardPatternController.onPageLoad(NormalMode)
-      }
+        "must go from the Index page to the Does Include Non-standard Pattern page" in {
+          navigator.nextPage(IndexPage, NormalMode, UserAnswers("id")) mustBe buildRoutes.ServiceURLController.onPageLoad(NormalMode)
+        }
 
-      "NORMALMODE must go from the Does Include Non-standard Pattern page to the Which Non-standard Pattern page WHEN answer is YES" in {
-        UserAnswers("id").set(DoesNonstandardPatternPage, true).foreach{userAnswers =>
-          navigator.nextPage(DoesNonstandardPatternPage, NormalMode, userAnswers) mustBe buildRoutes.NonstandardPatternController.onPageLoad(NormalMode)
+        "must go from the Service URL page to the Does Include Non-standard Pattern page" in {
+          navigator.nextPage(ServiceURLPage, NormalMode, UserAnswers("id")) mustBe buildRoutes.DoesNonstandardPatternController.onPageLoad(NormalMode)
+        }
+
+        "NORMALMODE must go from the Does Include Non-standard Pattern page to the Which Non-standard Pattern page WHEN answer is YES" in {
+          UserAnswers("id").set(DoesNonstandardPatternPage, true).foreach { userAnswers =>
+            navigator.nextPage(DoesNonstandardPatternPage, NormalMode, userAnswers) mustBe buildRoutes.NonstandardPatternController.onPageLoad(NormalMode)
+          }
+        }
+
+        "NORMALMODE must go from the Does Include Non-standard Pattern Page to Break Bobby Rules page WHEN answer is NO" in {
+          UserAnswers("id").set(DoesNonstandardPatternPage, false).foreach { userAnswers =>
+            navigator.nextPage(DoesNonstandardPatternPage, NormalMode, userAnswers) mustBe buildRoutes.BreakBobbyRulesController.onPageLoad(NormalMode)
+          }
+        }
+
+        "must go from the Which Non-standard Pattern page to the Bobby Rules page" in {
+          navigator.nextPage(NonstandardPatternPage, NormalMode, UserAnswers("id")) mustBe buildRoutes.BreakBobbyRulesController.onPageLoad(NormalMode)
+        }
+
+        "must go from the Bobby Rules page to the Deprecated HMRC Libraries page" in {
+          navigator.nextPage(BreakBobbyRulesPage, NormalMode, UserAnswers("id")) mustBe buildRoutes.DeprecatedLibrariesController.onPageLoad(NormalMode)
+        }
+
+        "must go from the Deprecated HMRC Libraries page to the Using HTTP Verbs page" in {
+          navigator.nextPage(DeprecatedLibrariesPage, NormalMode, UserAnswers("id")) mustBe buildRoutes.UsingHTTPVerbsController.onPageLoad(NormalMode)
+        }
+
+        "must go from the HTTP Verbs page to the ReadME Up-To-Date and fit for purpose page" in {
+          navigator.nextPage(UsingHTTPVerbsPage, NormalMode, UserAnswers("id")) mustBe buildRoutes.ReadMeFitForPurposeController.onPageLoad(NormalMode)
+        }
+
+        "must go from the ReadME Up-To-Date and fit for purpose page to the Appropriate Timeouts page" in {
+          navigator.nextPage(ReadMeFitForPurposePage, NormalMode, UserAnswers("id")) mustBe buildRoutes.AppropriateTimeoutsController.onPageLoad(NormalMode)
+        }
+
+        "must go from the Appropriate Timeouts page to the Check Your Answers page" in {
+          navigator.nextPage(AppropriateTimeoutsPage, NormalMode, UserAnswers("id")) mustBe buildRoutes.CheckYourAnswersController.onPageLoad()
         }
       }
 
-      "NORMALMODE must go from the Does Include Non-standard Pattern Page to Break Bobby Rules page WHEN answer is NO" in {
-        UserAnswers("id").set(DoesNonstandardPatternPage, false).foreach{userAnswers =>
-          navigator.nextPage(DoesNonstandardPatternPage, NormalMode, userAnswers) mustBe buildRoutes.BreakBobbyRulesController.onPageLoad(NormalMode)
+
+      "in Data Persistence" - {
+
+        "must go from the Using Mongo page to the Resilient Recycling Mongo page" in {
+          navigator.nextPage(UsingMongoPage, NormalMode, UserAnswers("id")) mustBe dataRoutes.ResilientRecycleMongoController.onPageLoad(NormalMode)
         }
-      }
-
-      "must go from the Which Non-standard Pattern page to the Bobby Rules page" in {
-        navigator.nextPage(NonstandardPatternPage, NormalMode, UserAnswers("id")) mustBe buildRoutes.BreakBobbyRulesController.onPageLoad(NormalMode)
-      }
-
-      "must go from the Bobby Rules page to the Deprecated HMRC Libraries page" in {
-        navigator.nextPage(BreakBobbyRulesPage, NormalMode, UserAnswers("id")) mustBe buildRoutes.DeprecatedLibrariesController.onPageLoad(NormalMode)
-      }
-
-      "must go from the Deprecated HMRC Libraries page to the Using HTTP Verbs page" in {
-        navigator.nextPage(DeprecatedLibrariesPage, NormalMode, UserAnswers("id")) mustBe buildRoutes.UsingHTTPVerbsController.onPageLoad(NormalMode)
-      }
-
-      "must go from the HTTP Verbs page to the ReadME Up-To-Date and fit for purpose page" in {
-        navigator.nextPage(UsingHTTPVerbsPage, NormalMode, UserAnswers("id")) mustBe buildRoutes.ReadMeFitForPurposeController.onPageLoad(NormalMode)
-      }
-
-      "must go from the ReadME Up-To-Date and fit for purpose page to the Appropriate Timeouts page" in {
-        navigator.nextPage(ReadMeFitForPurposePage, NormalMode, UserAnswers("id")) mustBe buildRoutes.AppropriateTimeoutsController.onPageLoad(NormalMode)
-      }
-
-      "must go from the Appropriate Timeouts page to the Check Your Answers page" in {
-        navigator.nextPage(AppropriateTimeoutsPage, NormalMode, UserAnswers("id")) mustBe buildRoutes.CheckYourAnswersController.onPageLoad()
+        "must go from the UResilient Recycling Mongo page to the Public Mongo TTL page" in {
+          navigator.nextPage(ResilientRecycleMongoPage, NormalMode, UserAnswers("id")) mustBe dataRoutes.PublicMongoTTLController.onPageLoad(NormalMode)
+        }
+        "must go from the Public Mongo TTL page to the Field Level Encryption page" in {
+          navigator.nextPage(PublicMongoTTLPage, NormalMode, UserAnswers("id")) mustBe dataRoutes.FieldLevelEncryptionController.onPageLoad(NormalMode)
+        }
+        "must go from the Field Level Encryption page to the Protected Mongo TTL page" in {
+          navigator.nextPage(FieldLevelEncryptionPage, NormalMode, UserAnswers("id")) mustBe dataRoutes.ProtectedMongoTTLController.onPageLoad(NormalMode)
+        }
+        "must go from the Protected Mongo TTL page to the Mongo Tested With Indexing page" in {
+          navigator.nextPage(ProtectedMongoTTLPage, NormalMode, UserAnswers("id")) mustBe dataRoutes.MongoTestedWithIndexingController.onPageLoad(NormalMode)
+        }
+        "must go from the Mongo Tested With Indexing page to the Using Object Store page" in {
+          navigator.nextPage(MongoTestedWithIndexingPage, NormalMode, UserAnswers("id")) mustBe dataRoutes.UsingObjectStoreController.onPageLoad(NormalMode)
+        }
+        "must go from the Object Store page to the Correct Retention Period page" in {
+          navigator.nextPage(UsingObjectStorePage, NormalMode, UserAnswers("id")) mustBe dataRoutes.CorrectRetentionPeriodController.onPageLoad(NormalMode)
+        }
+        "must go from the Correct Retention Period page to the Check Your Answers page" in {
+          navigator.nextPage(CorrectRetentionPeriodPage, NormalMode, UserAnswers("id")) mustBe dataRoutes.CheckYourAnswersController.onPageLoad()
+        }
       }
     }
 


### PR DESCRIPTION
Implemented journey for new pages covered under section 2 (A-H) of the PRA.

Journey is detailed as followed:

- `/using-mongo` to `/resilient-recycle-mongo`
- `/resilient-recycle-mongo` to `/public-mongo-ttl`
- `/public-mongo-ttl` to `/field-level-encryption`
- `/field-level-encryption` to `/protected-mongo-ttl`
- `/protected-mongo-ttl` to `/mongo-tested-with-indexing`
- `/mongo-tested-with-indexing` to `/using-object-store`
- `/using-object-store` to `/correct-retention-period`
- `/correct-retention-period` to `/check-your-answers`

Currently there is no connecting journey between section 1 and section 2