### PR TITLE
Added PRA Section 4 Journey

### DIFF
--- a/app/controllers/security/CheckYourAnswersController.scala
+++ b/app/controllers/security/CheckYourAnswersController.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.security
+
+import com.google.inject.Inject
+import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierAction}
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import viewmodels.checkAnswers.security.*
+import viewmodels.govuk.summarylist.*
+import views.html.security.CheckYourAnswersView
+
+class CheckYourAnswersController @Inject()(
+                                            override val messagesApi: MessagesApi,
+                                            identify: IdentifierAction,
+                                            getData: DataRetrievalAction,
+                                            requireData: DataRequiredAction,
+                                            val controllerComponents: MessagesControllerComponents,
+                                            view: CheckYourAnswersView
+                                          ) extends FrontendBaseController with I18nSupport {
+
+  def onPageLoad(): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+      
+      val list = SummaryListViewModel(
+        rows = Seq(FrontendAuthenticationSummary.row(request.userAnswers),
+          PublicMicroserviceAuthSummary.row(request.userAnswers),
+          ProtectedMicroserviceAuthSummary.row(request.userAnswers)
+        ).flatten
+      )
+
+      Ok(view(list))
+
+  }
+}

--- a/app/controllers/security/FrontendAuthenticationController.scala
+++ b/app/controllers/security/FrontendAuthenticationController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.security
+
+import controllers.actions._
+import forms.security.FrontendAuthenticationFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.security.FrontendAuthenticationPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.security.FrontendAuthenticationView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class FrontendAuthenticationController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionService: SessionService,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: FrontendAuthenticationFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: FrontendAuthenticationView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(FrontendAuthenticationPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(FrontendAuthenticationPage, value))
+            _              <- sessionService.setUserAnswers(updatedAnswers)
+          } yield Redirect(navigator.nextPage(FrontendAuthenticationPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/security/ProtectedMicroserviceAuthController.scala
+++ b/app/controllers/security/ProtectedMicroserviceAuthController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.security
+
+import controllers.actions._
+import forms.security.ProtectedMicroserviceAuthFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.security.ProtectedMicroserviceAuthPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.security.ProtectedMicroserviceAuthView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ProtectedMicroserviceAuthController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionService: SessionService,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: ProtectedMicroserviceAuthFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: ProtectedMicroserviceAuthView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(ProtectedMicroserviceAuthPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(ProtectedMicroserviceAuthPage, value))
+            _              <- sessionService.setUserAnswers(updatedAnswers)
+          } yield Redirect(navigator.nextPage(ProtectedMicroserviceAuthPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/security/PublicMicroserviceAuthController.scala
+++ b/app/controllers/security/PublicMicroserviceAuthController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.security
+
+import controllers.actions._
+import forms.security.PublicMicroserviceAuthFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.security.PublicMicroserviceAuthPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.security.PublicMicroserviceAuthView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class PublicMicroserviceAuthController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionService: SessionService,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: PublicMicroserviceAuthFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: PublicMicroserviceAuthView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(PublicMicroserviceAuthPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(PublicMicroserviceAuthPage, value))
+            _              <- sessionService.setUserAnswers(updatedAnswers)
+          } yield Redirect(navigator.nextPage(PublicMicroserviceAuthPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/forms/security/FrontendAuthenticationFormProvider.scala
+++ b/app/forms/security/FrontendAuthenticationFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.security
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class FrontendAuthenticationFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("frontendAuthentication.error.required")
+    )
+}

--- a/app/forms/security/ProtectedMicroserviceAuthFormProvider.scala
+++ b/app/forms/security/ProtectedMicroserviceAuthFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.security
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class ProtectedMicroserviceAuthFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("protectedMicroserviceAuth.error.required")
+    )
+}

--- a/app/forms/security/PublicMicroserviceAuthFormProvider.scala
+++ b/app/forms/security/PublicMicroserviceAuthFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.security
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class PublicMicroserviceAuthFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("publicMicroserviceAuth.error.required")
+    )
+}

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -19,12 +19,14 @@ package navigation
 import controllers.buildResilience.routes as buildResilienceRoutes
 import controllers.dataPersistence.routes as dataPersistenceRoutes
 import controllers.commonServiceUsage.routes as commonServiceUsageRoutes
+import controllers.security.routes as securityRoutes
 import controllers.routes
 import models.*
 import pages.*
 import pages.buildResilience.{AppropriateTimeoutsPage, BreakBobbyRulesPage, DeprecatedLibrariesPage, DoesNonstandardPatternPage, NonstandardPatternPage, ReadMeFitForPurposePage, ServiceURLPage, UsingHTTPVerbsPage}
 import pages.commonServiceUsage.{IntegrationCheckPage, NotifyDependantServicesPage}
 import pages.dataPersistence.{CorrectRetentionPeriodPage, FieldLevelEncryptionPage, MongoTestedWithIndexingPage, ProtectedMongoTTLPage, PublicMongoTTLPage, ResilientRecycleMongoPage, UsingMongoPage, UsingObjectStorePage}
+import pages.security.{FrontendAuthenticationPage, ProtectedMicroserviceAuthPage, PublicMicroserviceAuthPage}
 import play.api.mvc.Call
 
 import javax.inject.{Inject, Singleton}
@@ -93,6 +95,18 @@ class Navigator @Inject()() {
 
     case NotifyDependantServicesPage => _ => commonServiceUsageRoutes.CheckYourAnswersController.onPageLoad()
 
+    /*######################################################
+
+                            SECURITY
+
+    #######################################################*/
+
+    case FrontendAuthenticationPage => _ => securityRoutes.PublicMicroserviceAuthController.onPageLoad(NormalMode)
+
+    case PublicMicroserviceAuthPage => _ => securityRoutes.ProtectedMicroserviceAuthController.onPageLoad(NormalMode)
+
+    case ProtectedMicroserviceAuthPage => _ => securityRoutes.CheckYourAnswersController.onPageLoad()
+
     case _ => _ => routes.IndexController.onPageLoad()
   }
 
@@ -156,7 +170,19 @@ class Navigator @Inject()() {
 
     case NotifyDependantServicesPage => _ => commonServiceUsageRoutes.CheckYourAnswersController.onPageLoad()
 
-    case _ => _ => commonServiceUsageRoutes.CheckYourAnswersController.onPageLoad()
+    /*######################################################
+
+                            SECURITY
+
+    #######################################################*/
+
+    case FrontendAuthenticationPage => _ => securityRoutes.CheckYourAnswersController.onPageLoad()
+
+    case PublicMicroserviceAuthPage => _ => securityRoutes.CheckYourAnswersController.onPageLoad()
+    
+    case ProtectedMicroserviceAuthPage => _ => securityRoutes.CheckYourAnswersController.onPageLoad() 
+
+    case _ => _ => securityRoutes.CheckYourAnswersController.onPageLoad()
   }
 
   def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers): Call = mode match {

--- a/app/pages/security/FrontendAuthenticationPage.scala
+++ b/app/pages/security/FrontendAuthenticationPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.security
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object FrontendAuthenticationPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "frontendAuthentication"
+}

--- a/app/pages/security/ProtectedMicroserviceAuthPage.scala
+++ b/app/pages/security/ProtectedMicroserviceAuthPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.security
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object ProtectedMicroserviceAuthPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "protectedMicroserviceAuth"
+}

--- a/app/pages/security/PublicMicroserviceAuthPage.scala
+++ b/app/pages/security/PublicMicroserviceAuthPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.security
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object PublicMicroserviceAuthPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "publicMicroserviceAuth"
+}

--- a/app/viewmodels/checkAnswers/security/FrontendAuthenticationSummary.scala
+++ b/app/viewmodels/checkAnswers/security/FrontendAuthenticationSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.security
+
+import controllers.security.routes
+import models.{CheckMode, UserAnswers}
+import pages.security.FrontendAuthenticationPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object FrontendAuthenticationSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(FrontendAuthenticationPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "frontendAuthentication.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.FrontendAuthenticationController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("frontendAuthentication.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/security/ProtectedMicroserviceAuthSummary.scala
+++ b/app/viewmodels/checkAnswers/security/ProtectedMicroserviceAuthSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.security
+
+import controllers.security.routes
+import models.{CheckMode, UserAnswers}
+import pages.security.ProtectedMicroserviceAuthPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object ProtectedMicroserviceAuthSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(ProtectedMicroserviceAuthPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "protectedMicroserviceAuth.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.ProtectedMicroserviceAuthController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("protectedMicroserviceAuth.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/security/PublicMicroserviceAuthSummary.scala
+++ b/app/viewmodels/checkAnswers/security/PublicMicroserviceAuthSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.security
+
+import controllers.security.routes
+import models.{CheckMode, UserAnswers}
+import pages.security.PublicMicroserviceAuthPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object PublicMicroserviceAuthSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(PublicMicroserviceAuthPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "publicMicroserviceAuth.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.PublicMicroserviceAuthController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("publicMicroserviceAuth.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/views/security/CheckYourAnswersView.scala.html
+++ b/app/views/security/CheckYourAnswersView.scala.html
@@ -14,12 +14,9 @@
  * limitations under the License.
  *@
 
-@import controllers.security.routes as securityRoutes
-
 @this(
     layout: templates.Layout,
     govukSummaryList: GovukSummaryList,
-    govukButton: GovukButton
 )
 
 @(list: SummaryList)(implicit request: Request[_], messages: Messages)
@@ -30,11 +27,4 @@
 
     @govukSummaryList(list)
 
-    <div>
-        @govukButton(
-            ButtonViewModel(messages("site.continue"))
-                .withAttribute("id","continue")
-                .asLink(securityRoutes.FrontendAuthenticationController.onPageLoad(NormalMode).url)
-        )
-    </div>
 }

--- a/app/views/security/FrontendAuthenticationView.scala.html
+++ b/app/views/security/FrontendAuthenticationView.scala.html
@@ -24,6 +24,12 @@
 
 @(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
 
+@hintPanel() = {
+<div>
+    <p class="govuk-body">@messages("frontendAuthentication.hint") <a href="https://confluence.tools.tax.service.gov.uk/display/SI/Security+Integration">@messages("frontendAuthentication.hintAnchor")</a> @messages("frontendAuthentication.hint2")</p>
+</div>
+}
+
 @layout(pageTitle = title(form, messages("frontendAuthentication.title"))) {
 
     @formHelper(action = controllers.security.routes.FrontendAuthenticationController.onSubmit(mode), Symbol("autoComplete") -> "off") {
@@ -36,7 +42,7 @@
             RadiosViewModel.yesNo(
                 field = form("value"),
                 legend = LegendViewModel(messages("frontendAuthentication.heading")).asPageHeading()
-            )
+            ).withHint(Hint(content = HtmlContent(hintPanel())))
         )
 
         @govukButton(

--- a/app/views/security/FrontendAuthenticationView.scala.html
+++ b/app/views/security/FrontendAuthenticationView.scala.html
@@ -14,27 +14,33 @@
  * limitations under the License.
  *@
 
-@import controllers.security.routes as securityRoutes
-
 @this(
     layout: templates.Layout,
-    govukSummaryList: GovukSummaryList,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
     govukButton: GovukButton
 )
 
-@(list: SummaryList)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
 
-@layout(pageTitle = titleNoForm(messages("checkYourAnswers.title"))) {
+@layout(pageTitle = title(form, messages("frontendAuthentication.title"))) {
 
-    <h1 class="govuk-heading-xl">@messages("checkYourAnswers.heading")</h1>
+    @formHelper(action = controllers.security.routes.FrontendAuthenticationController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
-    @govukSummaryList(list)
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
 
-    <div>
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("frontendAuthentication.heading")).asPageHeading()
+            )
+        )
+
         @govukButton(
             ButtonViewModel(messages("site.continue"))
-                .withAttribute("id","continue")
-                .asLink(securityRoutes.FrontendAuthenticationController.onPageLoad(NormalMode).url)
         )
-    </div>
+    }
 }

--- a/app/views/security/ProtectedMicroserviceAuthView.scala.html
+++ b/app/views/security/ProtectedMicroserviceAuthView.scala.html
@@ -24,6 +24,12 @@
 
 @(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
 
+@hintPanel() = {
+<div>
+    <p class="govuk-body">@messages("protectedMicroserviceAuth.hint")</p>
+</div>
+}
+
 @layout(pageTitle = title(form, messages("protectedMicroserviceAuth.title"))) {
 
     @formHelper(action = controllers.security.routes.ProtectedMicroserviceAuthController.onSubmit(mode), Symbol("autoComplete") -> "off") {
@@ -36,7 +42,7 @@
             RadiosViewModel.yesNo(
                 field = form("value"),
                 legend = LegendViewModel(messages("protectedMicroserviceAuth.heading")).asPageHeading()
-            )
+            ).withHint(Hint(content = HtmlContent(hintPanel())))
         )
 
         @govukButton(

--- a/app/views/security/ProtectedMicroserviceAuthView.scala.html
+++ b/app/views/security/ProtectedMicroserviceAuthView.scala.html
@@ -14,27 +14,33 @@
  * limitations under the License.
  *@
 
-@import controllers.security.routes as securityRoutes
-
 @this(
     layout: templates.Layout,
-    govukSummaryList: GovukSummaryList,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
     govukButton: GovukButton
 )
 
-@(list: SummaryList)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
 
-@layout(pageTitle = titleNoForm(messages("checkYourAnswers.title"))) {
+@layout(pageTitle = title(form, messages("protectedMicroserviceAuth.title"))) {
 
-    <h1 class="govuk-heading-xl">@messages("checkYourAnswers.heading")</h1>
+    @formHelper(action = controllers.security.routes.ProtectedMicroserviceAuthController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
-    @govukSummaryList(list)
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
 
-    <div>
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("protectedMicroserviceAuth.heading")).asPageHeading()
+            )
+        )
+
         @govukButton(
             ButtonViewModel(messages("site.continue"))
-                .withAttribute("id","continue")
-                .asLink(securityRoutes.FrontendAuthenticationController.onPageLoad(NormalMode).url)
         )
-    </div>
+    }
 }

--- a/app/views/security/PublicMicroserviceAuthView.scala.html
+++ b/app/views/security/PublicMicroserviceAuthView.scala.html
@@ -14,27 +14,33 @@
  * limitations under the License.
  *@
 
-@import controllers.security.routes as securityRoutes
-
 @this(
     layout: templates.Layout,
-    govukSummaryList: GovukSummaryList,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
     govukButton: GovukButton
 )
 
-@(list: SummaryList)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
 
-@layout(pageTitle = titleNoForm(messages("checkYourAnswers.title"))) {
+@layout(pageTitle = title(form, messages("publicMicroserviceAuth.title"))) {
 
-    <h1 class="govuk-heading-xl">@messages("checkYourAnswers.heading")</h1>
+    @formHelper(action = controllers.security.routes.PublicMicroserviceAuthController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
-    @govukSummaryList(list)
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
 
-    <div>
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("publicMicroserviceAuth.heading")).asPageHeading()
+            )
+        )
+
         @govukButton(
             ButtonViewModel(messages("site.continue"))
-                .withAttribute("id","continue")
-                .asLink(securityRoutes.FrontendAuthenticationController.onPageLoad(NormalMode).url)
         )
-    </div>
+    }
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -8,6 +8,8 @@
 
 ->          /common-service-usage                        commonServiceUsage.Routes
 
+->          /security                                    security.Routes
+
 GET         /                                            controllers.IndexController.onPageLoad()
 
 GET         /assets/*file                                controllers.Assets.versioned(path="/public", file: Asset)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -190,3 +190,25 @@ notifyDependantServices.hint6 = EACD
 notifyDependantServices.hint7 = The rule of thumb here is that your service going into production and putting load (however big) onto your dependencies should
 notifyDependantServices.hint8 = not
 notifyDependantServices.hint9 = be a surprise to them.
+
+#========================================
+#               Security
+#========================================
+
+frontendAuthentication.title = frontendAuthentication
+frontendAuthentication.heading = frontendAuthentication
+frontendAuthentication.checkYourAnswersLabel = frontendAuthentication
+frontendAuthentication.error.required = Select yes if frontendAuthentication
+frontendAuthentication.change.hidden = FrontendAuthentication
+
+publicMicroserviceAuth.title = publicMicroserviceAuth
+publicMicroserviceAuth.heading = publicMicroserviceAuth
+publicMicroserviceAuth.checkYourAnswersLabel = publicMicroserviceAuth
+publicMicroserviceAuth.error.required = Select yes if publicMicroserviceAuth
+publicMicroserviceAuth.change.hidden = PublicMicroserviceAuth
+
+protectedMicroserviceAuth.title = protectedMicroserviceAuth
+protectedMicroserviceAuth.heading = protectedMicroserviceAuth
+protectedMicroserviceAuth.checkYourAnswersLabel = protectedMicroserviceAuth
+protectedMicroserviceAuth.error.required = Select yes if protectedMicroserviceAuth
+protectedMicroserviceAuth.change.hidden = ProtectedMicroserviceAuth

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -195,20 +195,24 @@ notifyDependantServices.hint9 = be a surprise to them.
 #               Security
 #========================================
 
-frontendAuthentication.title = frontendAuthentication
-frontendAuthentication.heading = frontendAuthentication
-frontendAuthentication.checkYourAnswersLabel = frontendAuthentication
-frontendAuthentication.error.required = Select yes if frontendAuthentication
+frontendAuthentication.title = Has your service gone through Security Integration?
+frontendAuthentication.heading = Has your service gone through Security Integration?
+frontendAuthentication.checkYourAnswersLabel = Has your service gone through Security Integration?
+frontendAuthentication.error.required = Select yes if your service has been through Security Integration
 frontendAuthentication.change.hidden = FrontendAuthentication
+frontendAuthentication.hint = We authenticate users via
+frontendAuthentication.hintAnchor = Security Integration Services
+frontendAuthentication.hint2 = when necessary
 
-publicMicroserviceAuth.title = publicMicroserviceAuth
-publicMicroserviceAuth.heading = publicMicroserviceAuth
-publicMicroserviceAuth.checkYourAnswersLabel = publicMicroserviceAuth
-publicMicroserviceAuth.error.required = Select yes if publicMicroserviceAuth
+publicMicroserviceAuth.title = Public Microservices should be authenticated and authorised by default.
+publicMicroserviceAuth.heading = Public Microservices should be authenticated and authorised by default.
+publicMicroserviceAuth.checkYourAnswersLabel = Public Microservices should be authenticated and authorised by default.
+publicMicroserviceAuth.error.required = Select yes if Public Microservices are being authenticated and authorised by default.
 publicMicroserviceAuth.change.hidden = PublicMicroserviceAuth
 
-protectedMicroserviceAuth.title = protectedMicroserviceAuth
-protectedMicroserviceAuth.heading = protectedMicroserviceAuth
-protectedMicroserviceAuth.checkYourAnswersLabel = protectedMicroserviceAuth
-protectedMicroserviceAuth.error.required = Select yes if protectedMicroserviceAuth
+protectedMicroserviceAuth.title =  Protected Microservices should be authenticated and authorised by default.
+protectedMicroserviceAuth.heading =  Protected Microservices should be authenticated and authorised by default.
+protectedMicroserviceAuth.checkYourAnswersLabel =  Protected Microservices should be authenticated and authorised by default.
+protectedMicroserviceAuth.error.required = Select yes if  Protected Microservices are being authenticated and authorised by default.
 protectedMicroserviceAuth.change.hidden = ProtectedMicroserviceAuth
+protectedMicroserviceAuth.hint = Internal Auth is an option for service-to-service authentication.

--- a/conf/security.routes
+++ b/conf/security.routes
@@ -1,0 +1,16 @@
+GET        /frontend-authentication                      controllers.security.FrontendAuthenticationController.onPageLoad(mode: Mode = NormalMode)
+POST       /frontend-authentication                      controllers.security.FrontendAuthenticationController.onSubmit(mode: Mode = NormalMode)
+GET        /change-frontend-authentication               controllers.security.FrontendAuthenticationController.onPageLoad(mode: Mode = CheckMode)
+POST       /change-frontend-authentication               controllers.security.FrontendAuthenticationController.onSubmit(mode: Mode = CheckMode)
+
+GET        /public-microservice-auth                     controllers.security.PublicMicroserviceAuthController.onPageLoad(mode: Mode = NormalMode)
+POST       /public-microservice-auth                     controllers.security.PublicMicroserviceAuthController.onSubmit(mode: Mode = NormalMode)
+GET        /change-public-microservice-auth              controllers.security.PublicMicroserviceAuthController.onPageLoad(mode: Mode = CheckMode)
+POST       /change-public-microservice-auth              controllers.security.PublicMicroserviceAuthController.onSubmit(mode: Mode = CheckMode)
+
+GET        /protected-microservice-auth                  controllers.security.ProtectedMicroserviceAuthController.onPageLoad(mode: Mode = NormalMode)
+POST       /protected-microservice-auth                  controllers.security.ProtectedMicroserviceAuthController.onSubmit(mode: Mode = NormalMode)
+GET        /change-protected-microservice-auth           controllers.security.ProtectedMicroserviceAuthController.onPageLoad(mode: Mode = CheckMode)
+POST       /change-protected-microservice-auth           controllers.security.ProtectedMicroserviceAuthController.onSubmit(mode: Mode = CheckMode)
+
+GET        /check-your-answers                           controllers.security.CheckYourAnswersController.onPageLoad()

--- a/test/controllers/security/FrontendAuthenticationControllerSpec.scala
+++ b/test/controllers/security/FrontendAuthenticationControllerSpec.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.security
+
+import controllers.routes
+import controllers.security.routes as securityRoutes
+
+import base.SpecBase
+import forms.security.FrontendAuthenticationFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.security.FrontendAuthenticationPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import services.SessionService
+import play.api.mvc.Results.NoContent
+import views.html.security.FrontendAuthenticationView
+
+import scala.concurrent.Future
+
+class FrontendAuthenticationControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new FrontendAuthenticationFormProvider()
+  val form = formProvider()
+
+  lazy val frontendAuthenticationRoute = securityRoutes.FrontendAuthenticationController.onPageLoad(NormalMode).url
+
+  "FrontendAuthentication Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, frontendAuthenticationRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[FrontendAuthenticationView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(FrontendAuthenticationPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, frontendAuthenticationRoute)
+
+        val view = application.injector.instanceOf[FrontendAuthenticationView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionService = mock[SessionService]
+
+      when(mockSessionService.setUserAnswers(any())(any())) thenReturn Future.successful(NoContent)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionService].toInstance(mockSessionService)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, frontendAuthenticationRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, frontendAuthenticationRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[FrontendAuthenticationView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, frontendAuthenticationRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, frontendAuthenticationRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/security/ProtectedMicroserviceAuthControllerSpec.scala
+++ b/test/controllers/security/ProtectedMicroserviceAuthControllerSpec.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.security
+
+import controllers.routes
+import controllers.security.routes as securityRoutes
+
+import base.SpecBase
+import forms.security.ProtectedMicroserviceAuthFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.security.ProtectedMicroserviceAuthPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import services.SessionService
+import play.api.mvc.Results.NoContent
+import views.html.security.ProtectedMicroserviceAuthView
+
+import scala.concurrent.Future
+
+class ProtectedMicroserviceAuthControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new ProtectedMicroserviceAuthFormProvider()
+  val form = formProvider()
+
+  lazy val protectedMicroserviceAuthRoute = securityRoutes.ProtectedMicroserviceAuthController.onPageLoad(NormalMode).url
+
+  "ProtectedMicroserviceAuth Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, protectedMicroserviceAuthRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[ProtectedMicroserviceAuthView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(ProtectedMicroserviceAuthPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, protectedMicroserviceAuthRoute)
+
+        val view = application.injector.instanceOf[ProtectedMicroserviceAuthView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionService = mock[SessionService]
+
+      when(mockSessionService.setUserAnswers(any())(any())) thenReturn Future.successful(NoContent)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionService].toInstance(mockSessionService)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, protectedMicroserviceAuthRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, protectedMicroserviceAuthRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[ProtectedMicroserviceAuthView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, protectedMicroserviceAuthRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, protectedMicroserviceAuthRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/security/PublicMicroserviceAuthControllerSpec.scala
+++ b/test/controllers/security/PublicMicroserviceAuthControllerSpec.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.security
+
+import controllers.routes
+import controllers.security.routes as securityRoutes
+
+import base.SpecBase
+import forms.security.PublicMicroserviceAuthFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.security.PublicMicroserviceAuthPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import services.SessionService
+import play.api.mvc.Results.NoContent
+import views.html.security.PublicMicroserviceAuthView
+
+import scala.concurrent.Future
+
+class PublicMicroserviceAuthControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new PublicMicroserviceAuthFormProvider()
+  val form = formProvider()
+
+  lazy val publicMicroserviceAuthRoute = securityRoutes.PublicMicroserviceAuthController.onPageLoad(NormalMode).url
+
+  "PublicMicroserviceAuth Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, publicMicroserviceAuthRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[PublicMicroserviceAuthView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(PublicMicroserviceAuthPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, publicMicroserviceAuthRoute)
+
+        val view = application.injector.instanceOf[PublicMicroserviceAuthView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionService = mock[SessionService]
+
+      when(mockSessionService.setUserAnswers(any())(any())) thenReturn Future.successful(NoContent)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionService].toInstance(mockSessionService)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, publicMicroserviceAuthRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, publicMicroserviceAuthRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[PublicMicroserviceAuthView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, publicMicroserviceAuthRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, publicMicroserviceAuthRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/forms/security/FrontendAuthenticationFormProviderSpec.scala
+++ b/test/forms/security/FrontendAuthenticationFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.security
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class FrontendAuthenticationFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "frontendAuthentication.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new FrontendAuthenticationFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/security/ProtectedMicroserviceAuthFormProviderSpec.scala
+++ b/test/forms/security/ProtectedMicroserviceAuthFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.security
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class ProtectedMicroserviceAuthFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "protectedMicroserviceAuth.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new ProtectedMicroserviceAuthFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/security/PublicMicroserviceAuthFormProviderSpec.scala
+++ b/test/forms/security/PublicMicroserviceAuthFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.security
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class PublicMicroserviceAuthFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "publicMicroserviceAuth.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new PublicMicroserviceAuthFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -21,11 +21,13 @@ import controllers.routes
 import controllers.buildResilience.routes as buildResilienceRoutes
 import controllers.dataPersistence.routes as dataPersistenceRoutes
 import controllers.commonServiceUsage.routes as commonServiceUsageRoutes
+import controllers.security.routes as securityRoutes
 import models.*
 import pages.*
 import pages.buildResilience.{AppropriateTimeoutsPage, BreakBobbyRulesPage, DeprecatedLibrariesPage, DoesNonstandardPatternPage, NonstandardPatternPage, ReadMeFitForPurposePage, ServiceURLPage, UsingHTTPVerbsPage}
 import pages.commonServiceUsage.{IntegrationCheckPage, NotifyDependantServicesPage}
 import pages.dataPersistence.{CorrectRetentionPeriodPage, FieldLevelEncryptionPage, MongoTestedWithIndexingPage, ProtectedMongoTTLPage, PublicMongoTTLPage, ResilientRecycleMongoPage, UsingMongoPage, UsingObjectStorePage}
+import pages.security.{FrontendAuthenticationPage, ProtectedMicroserviceAuthPage, PublicMicroserviceAuthPage}
 
 class NavigatorSpec extends SpecBase {
 
@@ -125,6 +127,19 @@ class NavigatorSpec extends SpecBase {
           navigator.nextPage(NotifyDependantServicesPage, NormalMode, UserAnswers("id")) mustBe commonServiceUsageRoutes.CheckYourAnswersController.onPageLoad()
         }
       }
+
+      "in Security" - {
+
+        "must go from the Frontend Authentication page to Public Microservice Auth page" in {
+          navigator.nextPage(FrontendAuthenticationPage, NormalMode, UserAnswers("id")) mustBe securityRoutes.PublicMicroserviceAuthController.onPageLoad(NormalMode)
+        }
+        "must go from the Public Microservice Auth page to Protected Microservice Auth page" in {
+          navigator.nextPage(PublicMicroserviceAuthPage, NormalMode, UserAnswers("id")) mustBe securityRoutes.ProtectedMicroserviceAuthController.onPageLoad(NormalMode)
+        }
+        "must go from Protected Microservice Auth page to Check Your Answers Page" in {
+          navigator.nextPage(ProtectedMicroserviceAuthPage, NormalMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
+        }
+      }
     }
 
     "in Check mode" - {
@@ -206,14 +221,27 @@ class NavigatorSpec extends SpecBase {
         "must go from the Integration Check page to Check Your Answers page" in {
           navigator.nextPage(IntegrationCheckPage, CheckMode, UserAnswers("id")) mustBe commonServiceUsageRoutes.CheckYourAnswersController.onPageLoad()
         }
-        "must go from the Notify Dependant Services page to Check Your Answers" in {
+        "must go from the Notify Dependant Services page to Check Your Answers page" in {
           navigator.nextPage(NotifyDependantServicesPage, CheckMode, UserAnswers("id")) mustBe commonServiceUsageRoutes.CheckYourAnswersController.onPageLoad()
+        }
+      }
+
+      "in Security" - {
+
+        "must go from the Frontend Authentication page to Check Your Answers page" in {
+          navigator.nextPage(FrontendAuthenticationPage, CheckMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
+        }
+        "must go from the Public Microservice Auth page to Check Your Answers page" in {
+          navigator.nextPage(PublicMicroserviceAuthPage, CheckMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
+        }
+        "must go from Protected Microservice Auth page to Check Your Answers Page" in {
+          navigator.nextPage(ProtectedMicroserviceAuthPage, CheckMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
         }
       }
 
       "must go from a page that doesn't exist in the edit route map to CheckYourAnswers" in {
         case object UnknownPage extends Page
-        navigator.nextPage(UnknownPage, CheckMode, UserAnswers("id")) mustBe commonServiceUsageRoutes.CheckYourAnswersController.onPageLoad()
+        navigator.nextPage(UnknownPage, CheckMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
       }
     }
   }


### PR DESCRIPTION
Added Section 4 "Security" from the PRA, including the full journey 4A-C with Check Your Answers page

Journey is now:

- `/common-service-usage/check-your-answers` to `/security/frontend-authentication`
- `/security/frontend-authentication` to `/security/public-microservice-auth`
- `/security/public-microservice-auth` to `/security/protected-microservice-auth`
- `/security/protected-microservice-auth` to `/security/check-your-answers`
