### PR TITLE
Moving Security navigation into seperate SecurityNavigator

### DIFF
--- a/app/controllers/security/FrontendAuthenticationController.scala
+++ b/app/controllers/security/FrontendAuthenticationController.scala
@@ -20,7 +20,7 @@ import controllers.actions._
 import forms.security.FrontendAuthenticationFormProvider
 import javax.inject.Inject
 import models.Mode
-import navigation.Navigator
+import navigation.SecurityNavigator
 import pages.security.FrontendAuthenticationPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class FrontendAuthenticationController @Inject()(
                                          override val messagesApi: MessagesApi,
                                          sessionService: SessionService,
-                                         navigator: Navigator,
+                                         navigator: SecurityNavigator,
                                          identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,

--- a/app/controllers/security/ProtectedMicroserviceAuthController.scala
+++ b/app/controllers/security/ProtectedMicroserviceAuthController.scala
@@ -20,7 +20,7 @@ import controllers.actions._
 import forms.security.ProtectedMicroserviceAuthFormProvider
 import javax.inject.Inject
 import models.Mode
-import navigation.Navigator
+import navigation.SecurityNavigator
 import pages.security.ProtectedMicroserviceAuthPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ProtectedMicroserviceAuthController @Inject()(
                                          override val messagesApi: MessagesApi,
                                          sessionService: SessionService,
-                                         navigator: Navigator,
+                                         navigator: SecurityNavigator,
                                          identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,

--- a/app/controllers/security/PublicMicroserviceAuthController.scala
+++ b/app/controllers/security/PublicMicroserviceAuthController.scala
@@ -20,7 +20,7 @@ import controllers.actions._
 import forms.security.PublicMicroserviceAuthFormProvider
 import javax.inject.Inject
 import models.Mode
-import navigation.Navigator
+import navigation.SecurityNavigator
 import pages.security.PublicMicroserviceAuthPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class PublicMicroserviceAuthController @Inject()(
                                          override val messagesApi: MessagesApi,
                                          sessionService: SessionService,
-                                         navigator: Navigator,
+                                         navigator: SecurityNavigator,
                                          identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -26,7 +26,6 @@ import pages.*
 import pages.buildResilience.{AppropriateTimeoutsPage, BreakBobbyRulesPage, DeprecatedLibrariesPage, DoesNonstandardPatternPage, NonstandardPatternPage, ReadMeFitForPurposePage, ServiceURLPage, UsingHTTPVerbsPage}
 import pages.commonServiceUsage.{IntegrationCheckPage, NotifyDependantServicesPage}
 import pages.dataPersistence.{CorrectRetentionPeriodPage, FieldLevelEncryptionPage, MongoTestedWithIndexingPage, ProtectedMongoTTLPage, PublicMongoTTLPage, ResilientRecycleMongoPage, UsingMongoPage, UsingObjectStorePage}
-import pages.security.{FrontendAuthenticationPage, ProtectedMicroserviceAuthPage, PublicMicroserviceAuthPage}
 import play.api.mvc.Call
 
 import javax.inject.{Inject, Singleton}
@@ -95,18 +94,6 @@ class Navigator @Inject()() {
 
     case NotifyDependantServicesPage => _ => commonServiceUsageRoutes.CheckYourAnswersController.onPageLoad()
 
-    /*######################################################
-
-                            SECURITY
-
-    #######################################################*/
-
-    case FrontendAuthenticationPage => _ => securityRoutes.PublicMicroserviceAuthController.onPageLoad(NormalMode)
-
-    case PublicMicroserviceAuthPage => _ => securityRoutes.ProtectedMicroserviceAuthController.onPageLoad(NormalMode)
-
-    case ProtectedMicroserviceAuthPage => _ => securityRoutes.CheckYourAnswersController.onPageLoad()
-
     case _ => _ => routes.IndexController.onPageLoad()
   }
 
@@ -169,18 +156,6 @@ class Navigator @Inject()() {
     case IntegrationCheckPage => _ => commonServiceUsageRoutes.CheckYourAnswersController.onPageLoad()
 
     case NotifyDependantServicesPage => _ => commonServiceUsageRoutes.CheckYourAnswersController.onPageLoad()
-
-    /*######################################################
-
-                            SECURITY
-
-    #######################################################*/
-
-    case FrontendAuthenticationPage => _ => securityRoutes.CheckYourAnswersController.onPageLoad()
-
-    case PublicMicroserviceAuthPage => _ => securityRoutes.CheckYourAnswersController.onPageLoad()
-    
-    case ProtectedMicroserviceAuthPage => _ => securityRoutes.CheckYourAnswersController.onPageLoad() 
 
     case _ => _ => securityRoutes.CheckYourAnswersController.onPageLoad()
   }

--- a/app/navigation/SecurityNavigator.scala
+++ b/app/navigation/SecurityNavigator.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package navigation
+
+import controllers.routes
+import controllers.security.routes as securityRoutes
+import models.*
+import pages.*
+import pages.security.{FrontendAuthenticationPage, ProtectedMicroserviceAuthPage, PublicMicroserviceAuthPage}
+import play.api.mvc.Call
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class SecurityNavigator @Inject()() {
+
+  private val normalRoutes: Page => UserAnswers => Call = {
+
+    case FrontendAuthenticationPage => _ => securityRoutes.PublicMicroserviceAuthController.onPageLoad(NormalMode)
+
+    case PublicMicroserviceAuthPage => _ => securityRoutes.ProtectedMicroserviceAuthController.onPageLoad(NormalMode)
+
+    case ProtectedMicroserviceAuthPage => _ => securityRoutes.CheckYourAnswersController.onPageLoad()
+
+    case _ => _ => routes.IndexController.onPageLoad()
+  }
+
+  private val checkRouteMap: Page => UserAnswers => Call = {
+
+    case FrontendAuthenticationPage => _ => securityRoutes.CheckYourAnswersController.onPageLoad()
+
+    case PublicMicroserviceAuthPage => _ => securityRoutes.CheckYourAnswersController.onPageLoad()
+    
+    case ProtectedMicroserviceAuthPage => _ => securityRoutes.CheckYourAnswersController.onPageLoad() 
+
+    case _ => _ => securityRoutes.CheckYourAnswersController.onPageLoad()
+  }
+
+  def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers): Call = mode match {
+    case NormalMode =>
+      normalRoutes(page)(userAnswers)
+    case CheckMode =>
+      checkRouteMap(page)(userAnswers)
+  }
+}

--- a/test/controllers/security/FrontendAuthenticationControllerSpec.scala
+++ b/test/controllers/security/FrontendAuthenticationControllerSpec.scala
@@ -18,11 +18,10 @@ package controllers.security
 
 import controllers.routes
 import controllers.security.routes as securityRoutes
-
 import base.SpecBase
 import forms.security.FrontendAuthenticationFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import navigation.{FakeSecurityNavigator, SecurityNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -30,7 +29,7 @@ import pages.security.FrontendAuthenticationPage
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import services.SessionService
 import play.api.mvc.Results.NoContent
 import views.html.security.FrontendAuthenticationView
@@ -91,7 +90,7 @@ class FrontendAuthenticationControllerSpec extends SpecBase with MockitoSugar {
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SecurityNavigator].toInstance(new FakeSecurityNavigator(onwardRoute)),
             bind[SessionService].toInstance(mockSessionService)
           )
           .build()

--- a/test/controllers/security/ProtectedMicroserviceAuthControllerSpec.scala
+++ b/test/controllers/security/ProtectedMicroserviceAuthControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.security.routes as securityRoutes
 import base.SpecBase
 import forms.security.ProtectedMicroserviceAuthFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import navigation.{FakeSecurityNavigator, SecurityNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -91,7 +91,7 @@ class ProtectedMicroserviceAuthControllerSpec extends SpecBase with MockitoSugar
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SecurityNavigator].toInstance(new FakeSecurityNavigator(onwardRoute)),
             bind[SessionService].toInstance(mockSessionService)
           )
           .build()

--- a/test/controllers/security/PublicMicroserviceAuthControllerSpec.scala
+++ b/test/controllers/security/PublicMicroserviceAuthControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.security.routes as securityRoutes
 import base.SpecBase
 import forms.security.PublicMicroserviceAuthFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import navigation.{FakeSecurityNavigator, SecurityNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -91,7 +91,7 @@ class PublicMicroserviceAuthControllerSpec extends SpecBase with MockitoSugar {
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SecurityNavigator].toInstance(new FakeSecurityNavigator(onwardRoute)),
             bind[SessionService].toInstance(mockSessionService)
           )
           .build()

--- a/test/navigation/FakeSecurityNavigator.scala
+++ b/test/navigation/FakeSecurityNavigator.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package navigation
+
+import models.{Mode, UserAnswers}
+import pages.*
+import play.api.mvc.Call
+
+class FakeSecurityNavigator(desiredRoute: Call) extends SecurityNavigator {
+
+  override def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers): Call =
+    desiredRoute
+}

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -127,19 +127,6 @@ class NavigatorSpec extends SpecBase {
           navigator.nextPage(NotifyDependantServicesPage, NormalMode, UserAnswers("id")) mustBe commonServiceUsageRoutes.CheckYourAnswersController.onPageLoad()
         }
       }
-
-      "in Security" - {
-
-        "must go from the Frontend Authentication page to Public Microservice Auth page" in {
-          navigator.nextPage(FrontendAuthenticationPage, NormalMode, UserAnswers("id")) mustBe securityRoutes.PublicMicroserviceAuthController.onPageLoad(NormalMode)
-        }
-        "must go from the Public Microservice Auth page to Protected Microservice Auth page" in {
-          navigator.nextPage(PublicMicroserviceAuthPage, NormalMode, UserAnswers("id")) mustBe securityRoutes.ProtectedMicroserviceAuthController.onPageLoad(NormalMode)
-        }
-        "must go from Protected Microservice Auth page to Check Your Answers Page" in {
-          navigator.nextPage(ProtectedMicroserviceAuthPage, NormalMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
-        }
-      }
     }
 
     "in Check mode" - {
@@ -223,19 +210,6 @@ class NavigatorSpec extends SpecBase {
         }
         "must go from the Notify Dependant Services page to Check Your Answers page" in {
           navigator.nextPage(NotifyDependantServicesPage, CheckMode, UserAnswers("id")) mustBe commonServiceUsageRoutes.CheckYourAnswersController.onPageLoad()
-        }
-      }
-
-      "in Security" - {
-
-        "must go from the Frontend Authentication page to Check Your Answers page" in {
-          navigator.nextPage(FrontendAuthenticationPage, CheckMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
-        }
-        "must go from the Public Microservice Auth page to Check Your Answers page" in {
-          navigator.nextPage(PublicMicroserviceAuthPage, CheckMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
-        }
-        "must go from Protected Microservice Auth page to Check Your Answers Page" in {
-          navigator.nextPage(ProtectedMicroserviceAuthPage, CheckMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
         }
       }
 

--- a/test/navigation/SecurityNavigatorSpec.scala
+++ b/test/navigation/SecurityNavigatorSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package navigation
+
+import base.SpecBase
+import controllers.security.routes as securityRoutes
+import models.*
+import pages.*
+import pages.security.{FrontendAuthenticationPage, ProtectedMicroserviceAuthPage, PublicMicroserviceAuthPage}
+
+class SecurityNavigatorSpec extends SpecBase {
+
+  val navigator = new SecurityNavigator
+
+  "SecurityNavigator" - {
+
+    "in Normal mode" - {
+
+      "must go from the Frontend Authentication page to Public Microservice Auth page" in {
+        navigator.nextPage(FrontendAuthenticationPage, NormalMode, UserAnswers("id")) mustBe securityRoutes.PublicMicroserviceAuthController.onPageLoad(NormalMode)
+      }
+      "must go from the Public Microservice Auth page to Protected Microservice Auth page" in {
+        navigator.nextPage(PublicMicroserviceAuthPage, NormalMode, UserAnswers("id")) mustBe securityRoutes.ProtectedMicroserviceAuthController.onPageLoad(NormalMode)
+      }
+      "must go from Protected Microservice Auth page to Check Your Answers Page" in {
+        navigator.nextPage(ProtectedMicroserviceAuthPage, NormalMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
+      }
+    }
+
+
+    "in Check mode" - {
+
+      "must go from the Frontend Authentication page to Check Your Answers page" in {
+        navigator.nextPage(FrontendAuthenticationPage, CheckMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
+      }
+      "must go from the Public Microservice Auth page to Check Your Answers page" in {
+        navigator.nextPage(PublicMicroserviceAuthPage, CheckMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
+      }
+      "must go from Protected Microservice Auth page to Check Your Answers Page" in {
+        navigator.nextPage(ProtectedMicroserviceAuthPage, CheckMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
+      }
+
+      "must go from a page that doesn't exist in the edit route map to CheckYourAnswers" in {
+        case object UnknownPage extends Page
+        navigator.nextPage(UnknownPage, CheckMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Created a SecurityNavigator class which contains only the navigation functionality for the `/security` path.

Removed the Security section from the Navigator class and moved all its functions to this new SecurityNavigator

created a FakeSecurityNavigator to extend SecurityNavigator to accommodate the tests for the `/security` navigation.