### PR TITLE
Moving DataPersistence navigation into separate DataPersistenceNavigator

### DIFF
--- a/app/controllers/dataPersistence/CorrectRetentionPeriodController.scala
+++ b/app/controllers/dataPersistence/CorrectRetentionPeriodController.scala
@@ -19,7 +19,7 @@ package controllers.dataPersistence
 import controllers.actions.*
 import forms.dataPersistence.CorrectRetentionPeriodFormProvider
 import models.Mode
-import navigation.Navigator
+import navigation.DataPersistenceNavigator
 import pages.dataPersistence.CorrectRetentionPeriodPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class CorrectRetentionPeriodController @Inject()(
                                          override val messagesApi: MessagesApi,
                                          sessionService: SessionService,
-                                         navigator: Navigator,
+                                         navigator: DataPersistenceNavigator,
                                          identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,

--- a/app/controllers/dataPersistence/FieldLevelEncryptionController.scala
+++ b/app/controllers/dataPersistence/FieldLevelEncryptionController.scala
@@ -19,7 +19,7 @@ package controllers.dataPersistence
 import controllers.actions.*
 import forms.dataPersistence.FieldLevelEncryptionFormProvider
 import models.Mode
-import navigation.Navigator
+import navigation.DataPersistenceNavigator
 import pages.dataPersistence.FieldLevelEncryptionPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class FieldLevelEncryptionController @Inject()(
                                          override val messagesApi: MessagesApi,
                                          sessionService: SessionService,
-                                         navigator: Navigator,
+                                         navigator: DataPersistenceNavigator,
                                          identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,

--- a/app/controllers/dataPersistence/MongoTestedWithIndexingController.scala
+++ b/app/controllers/dataPersistence/MongoTestedWithIndexingController.scala
@@ -19,7 +19,7 @@ package controllers.dataPersistence
 import controllers.actions.*
 import forms.dataPersistence.MongoTestedWithIndexingFormProvider
 import models.Mode
-import navigation.Navigator
+import navigation.DataPersistenceNavigator
 import pages.dataPersistence.MongoTestedWithIndexingPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class MongoTestedWithIndexingController @Inject()(
                                          override val messagesApi: MessagesApi,
                                          sessionService: SessionService,
-                                         navigator: Navigator,
+                                         navigator: DataPersistenceNavigator,
                                          identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,

--- a/app/controllers/dataPersistence/ProtectedMongoTTLController.scala
+++ b/app/controllers/dataPersistence/ProtectedMongoTTLController.scala
@@ -19,7 +19,7 @@ package controllers.dataPersistence
 import controllers.actions.*
 import forms.dataPersistence.ProtectedMongoTTLFormProvider
 import models.Mode
-import navigation.Navigator
+import navigation.DataPersistenceNavigator
 import pages.dataPersistence.ProtectedMongoTTLPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ProtectedMongoTTLController @Inject()(
                                          override val messagesApi: MessagesApi,
                                          sessionService: SessionService,
-                                         navigator: Navigator,
+                                         navigator: DataPersistenceNavigator,
                                          identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,

--- a/app/controllers/dataPersistence/PublicMongoTTLController.scala
+++ b/app/controllers/dataPersistence/PublicMongoTTLController.scala
@@ -19,7 +19,7 @@ package controllers.dataPersistence
 import controllers.actions.*
 import forms.dataPersistence.PublicMongoTTLFormProvider
 import models.Mode
-import navigation.Navigator
+import navigation.DataPersistenceNavigator
 import pages.dataPersistence.PublicMongoTTLPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class PublicMongoTTLController @Inject()(
                                          override val messagesApi: MessagesApi,
                                          sessionService: SessionService,
-                                         navigator: Navigator,
+                                         navigator: DataPersistenceNavigator,
                                          identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,

--- a/app/controllers/dataPersistence/ResilientRecycleMongoController.scala
+++ b/app/controllers/dataPersistence/ResilientRecycleMongoController.scala
@@ -19,7 +19,7 @@ package controllers.dataPersistence
 import controllers.actions.*
 import forms.dataPersistence.ResilientRecycleMongoFormProvider
 import models.Mode
-import navigation.Navigator
+import navigation.DataPersistenceNavigator
 import pages.dataPersistence.ResilientRecycleMongoPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ResilientRecycleMongoController @Inject()(
                                          override val messagesApi: MessagesApi,
                                          sessionService: SessionService,
-                                         navigator: Navigator,
+                                         navigator: DataPersistenceNavigator,
                                          identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,

--- a/app/controllers/dataPersistence/UsingMongoController.scala
+++ b/app/controllers/dataPersistence/UsingMongoController.scala
@@ -19,7 +19,7 @@ package controllers.dataPersistence
 import controllers.actions.*
 import forms.dataPersistence.UsingMongoFormProvider
 import models.Mode
-import navigation.Navigator
+import navigation.DataPersistenceNavigator
 import pages.dataPersistence.UsingMongoPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class UsingMongoController @Inject()(
                                          override val messagesApi: MessagesApi,
                                          sessionService: SessionService,
-                                         navigator: Navigator,
+                                         navigator: DataPersistenceNavigator,
                                          identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,

--- a/app/controllers/dataPersistence/UsingObjectStoreController.scala
+++ b/app/controllers/dataPersistence/UsingObjectStoreController.scala
@@ -19,7 +19,7 @@ package controllers.dataPersistence
 import controllers.actions.*
 import forms.dataPersistence.UsingObjectStoreFormProvider
 import models.Mode
-import navigation.Navigator
+import navigation.DataPersistenceNavigator
 import pages.dataPersistence.UsingObjectStorePage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class UsingObjectStoreController @Inject()(
                                          override val messagesApi: MessagesApi,
                                          sessionService: SessionService,
-                                         navigator: Navigator,
+                                         navigator: DataPersistenceNavigator,
                                          identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,

--- a/app/navigation/DataPersistenceNavigator.scala
+++ b/app/navigation/DataPersistenceNavigator.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package navigation
+
+import controllers.dataPersistence.routes as dataPersistenceRoutes
+import controllers.routes
+import controllers.security.routes as securityRoutes
+import models.*
+import pages.*
+import pages.dataPersistence.*
+import play.api.mvc.Call
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class DataPersistenceNavigator @Inject()() {
+
+  private val normalRoutes: Page => UserAnswers => Call = {
+
+    case UsingMongoPage => _ => dataPersistenceRoutes.ResilientRecycleMongoController.onPageLoad(NormalMode)
+
+    case ResilientRecycleMongoPage => _ => dataPersistenceRoutes.PublicMongoTTLController.onPageLoad(NormalMode)
+
+    case PublicMongoTTLPage => _ => dataPersistenceRoutes.FieldLevelEncryptionController.onPageLoad(NormalMode)
+
+    case FieldLevelEncryptionPage => _ => dataPersistenceRoutes.ProtectedMongoTTLController.onPageLoad(NormalMode)
+
+    case ProtectedMongoTTLPage => _ => dataPersistenceRoutes.MongoTestedWithIndexingController.onPageLoad(NormalMode)
+
+    case MongoTestedWithIndexingPage => _ => dataPersistenceRoutes.UsingObjectStoreController.onPageLoad(NormalMode)
+
+    case UsingObjectStorePage => _ => dataPersistenceRoutes.CorrectRetentionPeriodController.onPageLoad(NormalMode)
+
+    case CorrectRetentionPeriodPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+
+    case _ => _ => routes.IndexController.onPageLoad()
+  }
+
+  private val checkRouteMap: Page => UserAnswers => Call = {
+
+    case UsingMongoPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+
+    case ResilientRecycleMongoPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+
+    case PublicMongoTTLPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+
+    case FieldLevelEncryptionPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+
+    case ProtectedMongoTTLPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+
+    case MongoTestedWithIndexingPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+
+    case UsingObjectStorePage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+
+    case CorrectRetentionPeriodPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+
+    case _ => _ => securityRoutes.CheckYourAnswersController.onPageLoad()
+  }
+
+  def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers): Call = mode match {
+    case NormalMode =>
+      normalRoutes(page)(userAnswers)
+    case CheckMode =>
+      checkRouteMap(page)(userAnswers)
+  }
+}

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -17,13 +17,11 @@
 package navigation
 
 import controllers.buildResilience.routes as buildResilienceRoutes
-import controllers.dataPersistence.routes as dataPersistenceRoutes
 import controllers.security.routes as securityRoutes
 import controllers.routes
 import models.*
 import pages.*
 import pages.buildResilience.{AppropriateTimeoutsPage, BreakBobbyRulesPage, DeprecatedLibrariesPage, DoesNonstandardPatternPage, NonstandardPatternPage, ReadMeFitForPurposePage, ServiceURLPage, UsingHTTPVerbsPage}
-import pages.dataPersistence.{CorrectRetentionPeriodPage, FieldLevelEncryptionPage, MongoTestedWithIndexingPage, ProtectedMongoTTLPage, PublicMongoTTLPage, ResilientRecycleMongoPage, UsingMongoPage, UsingObjectStorePage}
 import play.api.mvc.Call
 
 import javax.inject.{Inject, Singleton}
@@ -60,28 +58,6 @@ class Navigator @Inject()() {
 
     case AppropriateTimeoutsPage => _ => buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
 
-    /*######################################################
-
-                      DATA PERSISTENCE
-
-    #######################################################*/
-
-    case UsingMongoPage => _ => dataPersistenceRoutes.ResilientRecycleMongoController.onPageLoad(NormalMode)
-
-    case ResilientRecycleMongoPage => _ => dataPersistenceRoutes.PublicMongoTTLController.onPageLoad(NormalMode)
-
-    case PublicMongoTTLPage => _ => dataPersistenceRoutes.FieldLevelEncryptionController.onPageLoad(NormalMode)
-
-    case FieldLevelEncryptionPage => _ => dataPersistenceRoutes.ProtectedMongoTTLController.onPageLoad(NormalMode)
-
-    case ProtectedMongoTTLPage => _ => dataPersistenceRoutes.MongoTestedWithIndexingController.onPageLoad(NormalMode)
-
-    case MongoTestedWithIndexingPage => _ => dataPersistenceRoutes.UsingObjectStoreController.onPageLoad(NormalMode)
-
-    case UsingObjectStorePage => _ => dataPersistenceRoutes.CorrectRetentionPeriodController.onPageLoad(NormalMode)
-
-    case CorrectRetentionPeriodPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-
     case _ => _ => routes.IndexController.onPageLoad()
   }
 
@@ -112,28 +88,6 @@ class Navigator @Inject()() {
     case ReadMeFitForPurposePage => _ => buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
 
     case AppropriateTimeoutsPage => _ => buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
-
-    /*######################################################
-
-                      DATA PERSISTENCE
-
-    #######################################################*/
-
-    case UsingMongoPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-
-    case ResilientRecycleMongoPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-
-    case PublicMongoTTLPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-
-    case FieldLevelEncryptionPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-
-    case ProtectedMongoTTLPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-
-    case MongoTestedWithIndexingPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-
-    case UsingObjectStorePage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-
-    case CorrectRetentionPeriodPage => _ => dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
 
     case _ => _ => securityRoutes.CheckYourAnswersController.onPageLoad()
   }

--- a/test/controllers/dataPersistence/CorrectRetentionPeriodControllerSpec.scala
+++ b/test/controllers/dataPersistence/CorrectRetentionPeriodControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import controllers.dataPersistence.routes as dataRoutes
 import forms.dataPersistence.CorrectRetentionPeriodFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import navigation.{FakeDataPersistenceNavigator, DataPersistenceNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -90,7 +90,7 @@ class CorrectRetentionPeriodControllerSpec extends SpecBase with MockitoSugar {
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[DataPersistenceNavigator].toInstance(new FakeDataPersistenceNavigator(onwardRoute)),
             bind[SessionService].toInstance(mockSessionService)
           )
           .build()

--- a/test/controllers/dataPersistence/FieldLevelEncryptionControllerSpec.scala
+++ b/test/controllers/dataPersistence/FieldLevelEncryptionControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import controllers.dataPersistence.routes as dataRoutes
 import forms.dataPersistence.FieldLevelEncryptionFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import navigation.{FakeDataPersistenceNavigator, DataPersistenceNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -90,7 +90,7 @@ class FieldLevelEncryptionControllerSpec extends SpecBase with MockitoSugar {
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[DataPersistenceNavigator].toInstance(new FakeDataPersistenceNavigator(onwardRoute)),
             bind[SessionService].toInstance(mockSessionService)
           )
           .build()

--- a/test/controllers/dataPersistence/MongoTestedWithIndexingControllerSpec.scala
+++ b/test/controllers/dataPersistence/MongoTestedWithIndexingControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import controllers.dataPersistence.routes as dataRoutes
 import forms.dataPersistence.MongoTestedWithIndexingFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import navigation.{FakeDataPersistenceNavigator, DataPersistenceNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -90,7 +90,7 @@ class MongoTestedWithIndexingControllerSpec extends SpecBase with MockitoSugar {
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[DataPersistenceNavigator].toInstance(new FakeDataPersistenceNavigator(onwardRoute)),
             bind[SessionService].toInstance(mockSessionService)
           )
           .build()

--- a/test/controllers/dataPersistence/ProtectedMongoTTLControllerSpec.scala
+++ b/test/controllers/dataPersistence/ProtectedMongoTTLControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import controllers.dataPersistence.routes as dataRoutes
 import forms.dataPersistence.ProtectedMongoTTLFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import navigation.{FakeDataPersistenceNavigator, DataPersistenceNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -90,7 +90,7 @@ class ProtectedMongoTTLControllerSpec extends SpecBase with MockitoSugar {
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[DataPersistenceNavigator].toInstance(new FakeDataPersistenceNavigator(onwardRoute)),
             bind[SessionService].toInstance(mockSessionService)
           )
           .build()

--- a/test/controllers/dataPersistence/PublicMongoTTLControllerSpec.scala
+++ b/test/controllers/dataPersistence/PublicMongoTTLControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import controllers.dataPersistence.routes as dataRoutes
 import forms.dataPersistence.PublicMongoTTLFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import navigation.{FakeDataPersistenceNavigator, DataPersistenceNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -90,7 +90,7 @@ class PublicMongoTTLControllerSpec extends SpecBase with MockitoSugar {
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[DataPersistenceNavigator].toInstance(new FakeDataPersistenceNavigator(onwardRoute)),
             bind[SessionService].toInstance(mockSessionService)
           )
           .build()

--- a/test/controllers/dataPersistence/ResilientRecycleMongoControllerSpec.scala
+++ b/test/controllers/dataPersistence/ResilientRecycleMongoControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import controllers.dataPersistence.routes as dataRoutes
 import forms.dataPersistence.ResilientRecycleMongoFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import navigation.{FakeDataPersistenceNavigator, DataPersistenceNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -90,7 +90,7 @@ class ResilientRecycleMongoControllerSpec extends SpecBase with MockitoSugar {
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[DataPersistenceNavigator].toInstance(new FakeDataPersistenceNavigator(onwardRoute)),
             bind[SessionService].toInstance(mockSessionService)
           )
           .build()

--- a/test/controllers/dataPersistence/UsingMongoControllerSpec.scala
+++ b/test/controllers/dataPersistence/UsingMongoControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import controllers.dataPersistence.routes as dataRoutes
 import forms.dataPersistence.UsingMongoFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import navigation.{FakeDataPersistenceNavigator, DataPersistenceNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -90,7 +90,7 @@ class UsingMongoControllerSpec extends SpecBase with MockitoSugar {
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[DataPersistenceNavigator].toInstance(new FakeDataPersistenceNavigator(onwardRoute)),
             bind[SessionService].toInstance(mockSessionService)
           )
           .build()

--- a/test/controllers/dataPersistence/UsingObjectStoreControllerSpec.scala
+++ b/test/controllers/dataPersistence/UsingObjectStoreControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import controllers.dataPersistence.routes as dataRoutes
 import forms.dataPersistence.UsingObjectStoreFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import navigation.{FakeDataPersistenceNavigator, DataPersistenceNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -90,7 +90,7 @@ class UsingObjectStoreControllerSpec extends SpecBase with MockitoSugar {
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[DataPersistenceNavigator].toInstance(new FakeDataPersistenceNavigator(onwardRoute)),
             bind[SessionService].toInstance(mockSessionService)
           )
           .build()

--- a/test/navigation/DataPersistenceNavigatorSpec.scala
+++ b/test/navigation/DataPersistenceNavigatorSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package navigation
+
+import base.SpecBase
+import controllers.dataPersistence.routes as dataPersistenceRoutes
+import controllers.security.routes as securityRoutes
+import models.*
+import pages.*
+import pages.dataPersistence.*
+
+class DataPersistenceNavigatorSpec extends SpecBase {
+
+  val navigator = new DataPersistenceNavigator
+
+  "Navigator" - {
+
+    "in Normal mode" - {
+
+      "must go from the Using Mongo page to the Resilient Recycling Mongo page" in {
+        navigator.nextPage(UsingMongoPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.ResilientRecycleMongoController.onPageLoad(NormalMode)
+      }
+      "must go from the UResilient Recycling Mongo page to the Public Mongo TTL page" in {
+        navigator.nextPage(ResilientRecycleMongoPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.PublicMongoTTLController.onPageLoad(NormalMode)
+      }
+      "must go from the Public Mongo TTL page to the Field Level Encryption page" in {
+        navigator.nextPage(PublicMongoTTLPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.FieldLevelEncryptionController.onPageLoad(NormalMode)
+      }
+      "must go from the Field Level Encryption page to the Protected Mongo TTL page" in {
+        navigator.nextPage(FieldLevelEncryptionPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.ProtectedMongoTTLController.onPageLoad(NormalMode)
+      }
+      "must go from the Protected Mongo TTL page to the Mongo Tested With Indexing page" in {
+        navigator.nextPage(ProtectedMongoTTLPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.MongoTestedWithIndexingController.onPageLoad(NormalMode)
+      }
+      "must go from the Mongo Tested With Indexing page to the Using Object Store page" in {
+        navigator.nextPage(MongoTestedWithIndexingPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.UsingObjectStoreController.onPageLoad(NormalMode)
+      }
+      "must go from the Object Store page to the Correct Retention Period page" in {
+        navigator.nextPage(UsingObjectStorePage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CorrectRetentionPeriodController.onPageLoad(NormalMode)
+      }
+      "must go from the Correct Retention Period page to the Check Your Answers page" in {
+        navigator.nextPage(CorrectRetentionPeriodPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+      }
+    }
+
+    "in Check mode" - {
+
+      "must go from the Using Mongo page to the Check Your Answers page" in {
+        navigator.nextPage(UsingMongoPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+      }
+      "must go from the UResilient Recycling Mongo page to the Check Your Answers page" in {
+        navigator.nextPage(ResilientRecycleMongoPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+      }
+      "must go from the Public Mongo TTL page to the Check Your Answers page" in {
+        navigator.nextPage(PublicMongoTTLPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+      }
+      "must go from the Field Level Encryption page to the Check Your Answers page" in {
+        navigator.nextPage(FieldLevelEncryptionPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+      }
+      "must go from the Protected Mongo TTL page to the Check Your Answers page" in {
+        navigator.nextPage(ProtectedMongoTTLPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+      }
+      "must go from the Mongo Tested With Indexing page to the Check Your Answers page" in {
+        navigator.nextPage(MongoTestedWithIndexingPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+      }
+      "must go from the Object Store page to the CCheck Your Answers page" in {
+        navigator.nextPage(UsingObjectStorePage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+      }
+      "must go from the Correct Retention Period page to the Check Your Answers page" in {
+        navigator.nextPage(CorrectRetentionPeriodPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+      }
+    }
+
+    "must go from a page that doesn't exist in the edit route map to CheckYourAnswers" in {
+      case object UnknownPage extends Page
+      navigator.nextPage(UnknownPage, CheckMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
+    }
+  }
+}

--- a/test/navigation/FakeDataPersistenceNavigator.scala
+++ b/test/navigation/FakeDataPersistenceNavigator.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package navigation
+
+import models.{Mode, UserAnswers}
+import pages.*
+import play.api.mvc.Call
+
+class FakeDataPersistenceNavigator(desiredRoute: Call) extends DataPersistenceNavigator {
+
+  override def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers): Call =
+    desiredRoute
+}

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -34,166 +34,102 @@ class NavigatorSpec extends SpecBase {
 
     "in Normal mode" - {
 
-      "in Build & Resilience" - {
+      "must go from a page that doesn't exist in the route map to Index" in {
+        case object UnknownPage extends Page
+        navigator.nextPage(UnknownPage, NormalMode, UserAnswers("id")) mustBe routes.IndexController.onPageLoad()
+      }
 
-        "must go from a page that doesn't exist in the route map to Index" in {
-          case object UnknownPage extends Page
-          navigator.nextPage(UnknownPage, NormalMode, UserAnswers("id")) mustBe routes.IndexController.onPageLoad()
-        }
+      "must go from the Index page to the Does Include Non-standard Pattern page" in {
+        navigator.nextPage(IndexPage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.ServiceURLController.onPageLoad(NormalMode)
+      }
 
-        "must go from the Index page to the Does Include Non-standard Pattern page" in {
-          navigator.nextPage(IndexPage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.ServiceURLController.onPageLoad(NormalMode)
-        }
+      "must go from the Service URL page to the Does Include Non-standard Pattern page" in {
+        navigator.nextPage(ServiceURLPage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.DoesNonstandardPatternController.onPageLoad(NormalMode)
+      }
 
-        "must go from the Service URL page to the Does Include Non-standard Pattern page" in {
-          navigator.nextPage(ServiceURLPage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.DoesNonstandardPatternController.onPageLoad(NormalMode)
-        }
-
-        "NORMALMODE must go from the Does Include Non-standard Pattern page to the Which Non-standard Pattern page WHEN answer is YES" in {
-          UserAnswers("id").set(DoesNonstandardPatternPage, true).foreach { userAnswers =>
-            navigator.nextPage(DoesNonstandardPatternPage, NormalMode, userAnswers) mustBe buildResilienceRoutes.NonstandardPatternController.onPageLoad(NormalMode)
-          }
-        }
-
-        "NORMALMODE must go from the Does Include Non-standard Pattern Page to Break Bobby Rules page WHEN answer is NO" in {
-          UserAnswers("id").set(DoesNonstandardPatternPage, false).foreach { userAnswers =>
-            navigator.nextPage(DoesNonstandardPatternPage, NormalMode, userAnswers) mustBe buildResilienceRoutes.BreakBobbyRulesController.onPageLoad(NormalMode)
-          }
-        }
-
-        "must go from the Which Non-standard Pattern page to the Bobby Rules page" in {
-          navigator.nextPage(NonstandardPatternPage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.BreakBobbyRulesController.onPageLoad(NormalMode)
-        }
-
-        "must go from the Bobby Rules page to the Deprecated HMRC Libraries page" in {
-          navigator.nextPage(BreakBobbyRulesPage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.DeprecatedLibrariesController.onPageLoad(NormalMode)
-        }
-
-        "must go from the Deprecated HMRC Libraries page to the Using HTTP Verbs page" in {
-          navigator.nextPage(DeprecatedLibrariesPage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.UsingHTTPVerbsController.onPageLoad(NormalMode)
-        }
-
-        "must go from the HTTP Verbs page to the ReadME Up-To-Date and fit for purpose page" in {
-          navigator.nextPage(UsingHTTPVerbsPage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.ReadMeFitForPurposeController.onPageLoad(NormalMode)
-        }
-
-        "must go from the ReadME Up-To-Date and fit for purpose page to the Appropriate Timeouts page" in {
-          navigator.nextPage(ReadMeFitForPurposePage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.AppropriateTimeoutsController.onPageLoad(NormalMode)
-        }
-
-        "must go from the Appropriate Timeouts page to the Check Your Answers page" in {
-          navigator.nextPage(AppropriateTimeoutsPage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      "NORMALMODE must go from the Does Include Non-standard Pattern page to the Which Non-standard Pattern page WHEN answer is YES" in {
+        UserAnswers("id").set(DoesNonstandardPatternPage, true).foreach { userAnswers =>
+          navigator.nextPage(DoesNonstandardPatternPage, NormalMode, userAnswers) mustBe buildResilienceRoutes.NonstandardPatternController.onPageLoad(NormalMode)
         }
       }
 
+      "NORMALMODE must go from the Does Include Non-standard Pattern Page to Break Bobby Rules page WHEN answer is NO" in {
+        UserAnswers("id").set(DoesNonstandardPatternPage, false).foreach { userAnswers =>
+          navigator.nextPage(DoesNonstandardPatternPage, NormalMode, userAnswers) mustBe buildResilienceRoutes.BreakBobbyRulesController.onPageLoad(NormalMode)
+        }
+      }
 
-      "in Data Persistence" - {
+      "must go from the Which Non-standard Pattern page to the Bobby Rules page" in {
+        navigator.nextPage(NonstandardPatternPage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.BreakBobbyRulesController.onPageLoad(NormalMode)
+      }
 
-        "must go from the Using Mongo page to the Resilient Recycling Mongo page" in {
-          navigator.nextPage(UsingMongoPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.ResilientRecycleMongoController.onPageLoad(NormalMode)
-        }
-        "must go from the UResilient Recycling Mongo page to the Public Mongo TTL page" in {
-          navigator.nextPage(ResilientRecycleMongoPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.PublicMongoTTLController.onPageLoad(NormalMode)
-        }
-        "must go from the Public Mongo TTL page to the Field Level Encryption page" in {
-          navigator.nextPage(PublicMongoTTLPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.FieldLevelEncryptionController.onPageLoad(NormalMode)
-        }
-        "must go from the Field Level Encryption page to the Protected Mongo TTL page" in {
-          navigator.nextPage(FieldLevelEncryptionPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.ProtectedMongoTTLController.onPageLoad(NormalMode)
-        }
-        "must go from the Protected Mongo TTL page to the Mongo Tested With Indexing page" in {
-          navigator.nextPage(ProtectedMongoTTLPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.MongoTestedWithIndexingController.onPageLoad(NormalMode)
-        }
-        "must go from the Mongo Tested With Indexing page to the Using Object Store page" in {
-          navigator.nextPage(MongoTestedWithIndexingPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.UsingObjectStoreController.onPageLoad(NormalMode)
-        }
-        "must go from the Object Store page to the Correct Retention Period page" in {
-          navigator.nextPage(UsingObjectStorePage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CorrectRetentionPeriodController.onPageLoad(NormalMode)
-        }
-        "must go from the Correct Retention Period page to the Check Your Answers page" in {
-          navigator.nextPage(CorrectRetentionPeriodPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-        }
+      "must go from the Bobby Rules page to the Deprecated HMRC Libraries page" in {
+        navigator.nextPage(BreakBobbyRulesPage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.DeprecatedLibrariesController.onPageLoad(NormalMode)
+      }
+
+      "must go from the Deprecated HMRC Libraries page to the Using HTTP Verbs page" in {
+        navigator.nextPage(DeprecatedLibrariesPage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.UsingHTTPVerbsController.onPageLoad(NormalMode)
+      }
+
+      "must go from the HTTP Verbs page to the ReadME Up-To-Date and fit for purpose page" in {
+        navigator.nextPage(UsingHTTPVerbsPage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.ReadMeFitForPurposeController.onPageLoad(NormalMode)
+      }
+
+      "must go from the ReadME Up-To-Date and fit for purpose page to the Appropriate Timeouts page" in {
+        navigator.nextPage(ReadMeFitForPurposePage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.AppropriateTimeoutsController.onPageLoad(NormalMode)
+      }
+
+      "must go from the Appropriate Timeouts page to the Check Your Answers page" in {
+        navigator.nextPage(AppropriateTimeoutsPage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
       }
     }
 
     "in Check mode" - {
+      
+      "must go from the Service URL page to the Check Your Answers page" in {
+        navigator.nextPage(ServiceURLPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      }
 
-      "in Build & Resilience" - {
-
-        "must go from the Service URL page to the Check Your Answers page" in {
-          navigator.nextPage(ServiceURLPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
-        }
-
-        "CHECKMODE must go from the Does Include Non-standard Pattern Page to Which Non-standard Patterns page WHEN answer is YES" in {
-          UserAnswers("id").set(DoesNonstandardPatternPage, true).foreach { userAnswers =>
-            navigator.nextPage(DoesNonstandardPatternPage, CheckMode, userAnswers) mustBe buildResilienceRoutes.NonstandardPatternController.onPageLoad(CheckMode)
-          }
-        }
-
-        "CHECKMODE must go from the Does Include Non-standard Pattern Page to CheckYourAnswers page WHEN answer is NO" in {
-          UserAnswers("id").set(DoesNonstandardPatternPage, false).foreach { userAnswers =>
-            navigator.nextPage(DoesNonstandardPatternPage, CheckMode, userAnswers) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
-          }
-        }
-
-        "must go from the Which Non-standard Pattern page to the Check Your Answers page" in {
-          navigator.nextPage(NonstandardPatternPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
-        }
-
-        "must go from the Bobby Rules page to the Check Your Answers page" in {
-          navigator.nextPage(BreakBobbyRulesPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
-        }
-
-        "must go from the Deprecated HMRC Libraries page to the Check Your Answers page" in {
-          navigator.nextPage(DeprecatedLibrariesPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
-        }
-
-        "must go from the HTTP Verbs page to the Check Your Answers page" in {
-          navigator.nextPage(UsingHTTPVerbsPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
-        }
-
-        "must go from the ReadME Up-To-Date and fit for purpose page to the Check Your Answers page" in {
-          navigator.nextPage(ReadMeFitForPurposePage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
-        }
-
-        "must go from the Appropriate Timeouts page to the Check Your Answers page" in {
-          navigator.nextPage(AppropriateTimeoutsPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      "CHECKMODE must go from the Does Include Non-standard Pattern Page to Which Non-standard Patterns page WHEN answer is YES" in {
+        UserAnswers("id").set(DoesNonstandardPatternPage, true).foreach { userAnswers =>
+          navigator.nextPage(DoesNonstandardPatternPage, CheckMode, userAnswers) mustBe buildResilienceRoutes.NonstandardPatternController.onPageLoad(CheckMode)
         }
       }
 
-
-      "in Data Persistence" - {
-
-        "must go from the Using Mongo page to the Check Your Answers page" in {
-          navigator.nextPage(UsingMongoPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-        }
-        "must go from the UResilient Recycling Mongo page to the Check Your Answers page" in {
-          navigator.nextPage(ResilientRecycleMongoPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-        }
-        "must go from the Public Mongo TTL page to the Check Your Answers page" in {
-          navigator.nextPage(PublicMongoTTLPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-        }
-        "must go from the Field Level Encryption page to the Check Your Answers page" in {
-          navigator.nextPage(FieldLevelEncryptionPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-        }
-        "must go from the Protected Mongo TTL page to the Check Your Answers page" in {
-          navigator.nextPage(ProtectedMongoTTLPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-        }
-        "must go from the Mongo Tested With Indexing page to the Check Your Answers page" in {
-          navigator.nextPage(MongoTestedWithIndexingPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-        }
-        "must go from the Object Store page to the CCheck Your Answers page" in {
-          navigator.nextPage(UsingObjectStorePage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-        }
-        "must go from the Correct Retention Period page to the Check Your Answers page" in {
-          navigator.nextPage(CorrectRetentionPeriodPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+      "CHECKMODE must go from the Does Include Non-standard Pattern Page to CheckYourAnswers page WHEN answer is NO" in {
+        UserAnswers("id").set(DoesNonstandardPatternPage, false).foreach { userAnswers =>
+          navigator.nextPage(DoesNonstandardPatternPage, CheckMode, userAnswers) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
         }
       }
 
-      "must go from a page that doesn't exist in the edit route map to CheckYourAnswers" in {
-        case object UnknownPage extends Page
-        navigator.nextPage(UnknownPage, CheckMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
+      "must go from the Which Non-standard Pattern page to the Check Your Answers page" in {
+        navigator.nextPage(NonstandardPatternPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
       }
+
+      "must go from the Bobby Rules page to the Check Your Answers page" in {
+        navigator.nextPage(BreakBobbyRulesPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      }
+
+      "must go from the Deprecated HMRC Libraries page to the Check Your Answers page" in {
+        navigator.nextPage(DeprecatedLibrariesPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      }
+
+      "must go from the HTTP Verbs page to the Check Your Answers page" in {
+        navigator.nextPage(UsingHTTPVerbsPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      }
+
+      "must go from the ReadME Up-To-Date and fit for purpose page to the Check Your Answers page" in {
+        navigator.nextPage(ReadMeFitForPurposePage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      }
+
+      "must go from the Appropriate Timeouts page to the Check Your Answers page" in {
+        navigator.nextPage(AppropriateTimeoutsPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      }
+    }
+
+    "must go from a page that doesn't exist in the edit route map to CheckYourAnswers" in {
+      case object UnknownPage extends Page
+      navigator.nextPage(UnknownPage, CheckMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
     }
   }
 }


### PR DESCRIPTION
Created a DataPersistenceNavigator class which contains only the navigation functionality for the `/data-persistence` path.

Removed the DataPersistence section from the Navigator class and moved all its functions to this new DataPersistenceNavigator

created a FakeDataPersistenceNavigator to extend DataPersistenceNavigator to accommodate the tests for the `/date-persistence` navigation.
