### PR TITLE
Data persistence conditional routing & Clean Up

### DIFF
--- a/app/controllers/dataPersistence/CorrectRetentionPeriodController.scala
+++ b/app/controllers/dataPersistence/CorrectRetentionPeriodController.scala
@@ -57,9 +57,7 @@ class CorrectRetentionPeriodController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      val oldAnswers = request.userAnswers
-
+      
       form.bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),
@@ -68,7 +66,7 @@ class CorrectRetentionPeriodController @Inject()(
           for {
             updatedAnswers <- Future.fromTry(request.userAnswers.set(CorrectRetentionPeriodPage, value))
             _              <- sessionService.setUserAnswers(updatedAnswers)
-          } yield Redirect(navigator.nextPage(CorrectRetentionPeriodPage, mode, updatedAnswers, oldAnswers))
+          } yield Redirect(navigator.nextPage(CorrectRetentionPeriodPage, mode, updatedAnswers))
       )
   }
 }

--- a/app/controllers/dataPersistence/FieldLevelEncryptionController.scala
+++ b/app/controllers/dataPersistence/FieldLevelEncryptionController.scala
@@ -57,9 +57,7 @@ class FieldLevelEncryptionController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      val oldAnswers = request.userAnswers
-
+      
       form.bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),
@@ -68,7 +66,7 @@ class FieldLevelEncryptionController @Inject()(
           for {
             updatedAnswers <- Future.fromTry(request.userAnswers.set(FieldLevelEncryptionPage, value))
             _              <- sessionService.setUserAnswers(updatedAnswers)
-          } yield Redirect(navigator.nextPage(FieldLevelEncryptionPage, mode, updatedAnswers, oldAnswers))
+          } yield Redirect(navigator.nextPage(FieldLevelEncryptionPage, mode, updatedAnswers))
       )
   }
 }

--- a/app/controllers/dataPersistence/MongoTestedWithIndexingController.scala
+++ b/app/controllers/dataPersistence/MongoTestedWithIndexingController.scala
@@ -57,9 +57,7 @@ class MongoTestedWithIndexingController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      val oldAnswers = request.userAnswers
-
+      
       form.bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),
@@ -68,7 +66,7 @@ class MongoTestedWithIndexingController @Inject()(
           for {
             updatedAnswers <- Future.fromTry(request.userAnswers.set(MongoTestedWithIndexingPage, value))
             _              <- sessionService.setUserAnswers(updatedAnswers)
-          } yield Redirect(navigator.nextPage(MongoTestedWithIndexingPage, mode, updatedAnswers, oldAnswers))
+          } yield Redirect(navigator.nextPage(MongoTestedWithIndexingPage, mode, updatedAnswers))
       )
   }
 }

--- a/app/controllers/dataPersistence/ProtectedMongoTTLController.scala
+++ b/app/controllers/dataPersistence/ProtectedMongoTTLController.scala
@@ -57,9 +57,7 @@ class ProtectedMongoTTLController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      val oldAnswers = request.userAnswers
-
+      
       form.bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),
@@ -68,7 +66,7 @@ class ProtectedMongoTTLController @Inject()(
           for {
             updatedAnswers <- Future.fromTry(request.userAnswers.set(ProtectedMongoTTLPage, value))
             _              <- sessionService.setUserAnswers(updatedAnswers)
-          } yield Redirect(navigator.nextPage(ProtectedMongoTTLPage, mode, updatedAnswers, oldAnswers))
+          } yield Redirect(navigator.nextPage(ProtectedMongoTTLPage, mode, updatedAnswers))
       )
   }
 }

--- a/app/controllers/dataPersistence/PublicMongoTTLController.scala
+++ b/app/controllers/dataPersistence/PublicMongoTTLController.scala
@@ -57,9 +57,7 @@ class PublicMongoTTLController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      val oldAnswers = request.userAnswers
-
+      
       form.bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),
@@ -68,7 +66,7 @@ class PublicMongoTTLController @Inject()(
           for {
             updatedAnswers <- Future.fromTry(request.userAnswers.set(PublicMongoTTLPage, value))
             _              <- sessionService.setUserAnswers(updatedAnswers)
-          } yield Redirect(navigator.nextPage(PublicMongoTTLPage, mode, updatedAnswers, oldAnswers))
+          } yield Redirect(navigator.nextPage(PublicMongoTTLPage, mode, updatedAnswers))
       )
   }
 }

--- a/app/controllers/dataPersistence/ResilientRecycleMongoController.scala
+++ b/app/controllers/dataPersistence/ResilientRecycleMongoController.scala
@@ -57,9 +57,7 @@ class ResilientRecycleMongoController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      val oldAnswers = request.userAnswers
-
+      
       form.bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),
@@ -68,7 +66,7 @@ class ResilientRecycleMongoController @Inject()(
           for {
             updatedAnswers <- Future.fromTry(request.userAnswers.set(ResilientRecycleMongoPage, value))
             _              <- sessionService.setUserAnswers(updatedAnswers)
-          } yield Redirect(navigator.nextPage(ResilientRecycleMongoPage, mode, updatedAnswers, oldAnswers))
+          } yield Redirect(navigator.nextPage(ResilientRecycleMongoPage, mode, updatedAnswers))
       )
   }
 }

--- a/app/controllers/dataPersistence/UsingMongoController.scala
+++ b/app/controllers/dataPersistence/UsingMongoController.scala
@@ -44,8 +44,8 @@ class UsingMongoController @Inject()(
 
   val form = formProvider()
 
-  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
-    implicit request =>
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData){
+      implicit request =>
 
       val preparedForm = request.userAnswers.get(UsingMongoPage) match {
         case None => form
@@ -58,8 +58,6 @@ class UsingMongoController @Inject()(
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
       
-      val oldAnswers = request.userAnswers
-
       form.bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),
@@ -68,7 +66,7 @@ class UsingMongoController @Inject()(
           for {
             updatedAnswers <- Future.fromTry(request.userAnswers.set(UsingMongoPage, value))
             _              <- sessionService.setUserAnswers(updatedAnswers)
-          } yield Redirect(navigator.nextPage(UsingMongoPage, mode, updatedAnswers, oldAnswers))
+          } yield Redirect(navigator.nextPage(UsingMongoPage, mode, updatedAnswers))
       )
   }
 }

--- a/app/controllers/dataPersistence/UsingObjectStoreController.scala
+++ b/app/controllers/dataPersistence/UsingObjectStoreController.scala
@@ -40,7 +40,7 @@ class UsingObjectStoreController @Inject()(
                                          formProvider: UsingObjectStoreFormProvider,
                                          val controllerComponents: MessagesControllerComponents,
                                          view: UsingObjectStoreView
-                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+                                          )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
   val form = formProvider()
 
@@ -57,9 +57,7 @@ class UsingObjectStoreController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      val oldAnswers = request.userAnswers
-
+      
       form.bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),
@@ -68,7 +66,7 @@ class UsingObjectStoreController @Inject()(
           for {
             updatedAnswers <- Future.fromTry(request.userAnswers.set(UsingObjectStorePage, value))
             _              <- sessionService.setUserAnswers(updatedAnswers)
-          } yield Redirect(navigator.nextPage(UsingObjectStorePage, mode, updatedAnswers, oldAnswers))
+          } yield Redirect(navigator.nextPage(UsingObjectStorePage, mode, updatedAnswers))
       )
   }
 }

--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -63,6 +63,10 @@ final case class UserAnswers(
         page.cleanup(None, updatedAnswers)
     }
   }
+
+  def removeList(pages: List[Settable[_]]): Try[UserAnswers] =
+    pages.foldLeft(Try(this))((oldAnswerList, page) => oldAnswerList.flatMap(_.remove(page)))
+    
 }
 
 object UserAnswers {

--- a/app/models/requests/DataRequest.scala
+++ b/app/models/requests/DataRequest.scala
@@ -19,6 +19,10 @@ package models.requests
 import models.UserAnswers
 import play.api.mvc.{Request, WrappedRequest}
 
-case class OptionalDataRequest[A] (request: Request[A], userId: String, userAnswers: Option[UserAnswers]) extends WrappedRequest[A](request)
+case class OptionalDataRequest[A] (request: Request[A],
+                                   userId: String,
+                                   userAnswers: Option[UserAnswers]) extends WrappedRequest[A](request)
 
-case class DataRequest[A] (request: Request[A], userId: String, userAnswers: UserAnswers) extends WrappedRequest[A](request)
+case class DataRequest[A](request: Request[A],
+                          userId: String,
+                          userAnswers: UserAnswers) extends WrappedRequest[A](request)

--- a/app/navigation/DataPersistenceNavigator.scala
+++ b/app/navigation/DataPersistenceNavigator.scala
@@ -30,15 +30,7 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class DataPersistenceNavigator @Inject()() {
-
-//  private def previousAnswerHasChanged[A](oldAnswers: UserAnswers, userAnswers: UserAnswers, page: Gettable[A])(implicit rds: Reads[A]): Boolean = {
-//    
-//    (oldAnswers.get(page), userAnswers.get(page)) match {
-//      case (Some(old), Some(current)) => old != current
-//      case _ => false
-//    }
-//  }
-
+  
   private val normalRoutes: Page => UserAnswers => Call = {
 
     case UsingMongoPage => userAnswers =>

--- a/app/pages/dataPersistence/UsingMongoPage.scala
+++ b/app/pages/dataPersistence/UsingMongoPage.scala
@@ -16,12 +16,31 @@
 
 package pages.dataPersistence
 
+import models.UserAnswers
 import pages.QuestionPage
 import play.api.libs.json.JsPath
+
+import scala.util.{Success, Try}
 
 case object UsingMongoPage extends QuestionPage[Boolean] {
 
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "usingMongo"
+
+  override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] = {
+
+    val mongoPages: List[QuestionPage[_]] = List(
+      ResilientRecycleMongoPage,
+      PublicMongoTTLPage,
+      FieldLevelEncryptionPage,
+      ProtectedMongoTTLPage,
+      MongoTestedWithIndexingPage
+    )
+
+    value match {
+      case Some(false)  => userAnswers.removeList(mongoPages)
+      case _ => Success(userAnswers)
+    }
+  }
 }

--- a/app/pages/dataPersistence/UsingObjectStorePage.scala
+++ b/app/pages/dataPersistence/UsingObjectStorePage.scala
@@ -16,12 +16,27 @@
 
 package pages.dataPersistence
 
+import models.UserAnswers
 import pages.QuestionPage
 import play.api.libs.json.JsPath
+
+import scala.util.{Success, Try}
 
 case object UsingObjectStorePage extends QuestionPage[Boolean] {
 
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "usingObjectStore"
+
+  override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] = {
+
+    val objectPages: List[QuestionPage[_]] = List(
+      CorrectRetentionPeriodPage
+    )
+
+    value match {
+      case Some(false) => userAnswers.removeList(objectPages)
+      case _ => Success(userAnswers)
+    }
+  }
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.14.0"
+  private val bootstrapVersion = "9.16.0"
   private val hmrcMongoVersion = "2.6.0"
 
   val compile = Seq(

--- a/test/controllers/dataPersistence/UsingObjectStoreControllerSpec.scala
+++ b/test/controllers/dataPersistence/UsingObjectStoreControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import controllers.dataPersistence.routes as dataRoutes
 import forms.dataPersistence.UsingObjectStoreFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeDataPersistenceNavigator, DataPersistenceNavigator}
+import navigation.{DataPersistenceNavigator, FakeDataPersistenceNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/navigation/DataPersistenceNavigatorSpec.scala
+++ b/test/navigation/DataPersistenceNavigatorSpec.scala
@@ -31,127 +31,147 @@ class DataPersistenceNavigatorSpec extends SpecBase {
 
     "in Normal mode" - {
 
-      "NORMALMODE must go from the Using Mongo page to the Resilient Recycling Mongo WHEN answer is YES" in {
-        val oldAnswers = UserAnswers("id")
+      "must go from the Using Mongo page to the Resilient Recycling Mongo WHEN answer is YES" in {
         UserAnswers("id").set(UsingMongoPage, true).foreach { userAnswers =>
-          navigator.nextPage(UsingMongoPage, NormalMode, userAnswers, oldAnswers) mustBe dataPersistenceRoutes.ResilientRecycleMongoController.onPageLoad(NormalMode)
+          navigator.nextPage(UsingMongoPage, NormalMode, userAnswers) mustBe dataPersistenceRoutes.ResilientRecycleMongoController.onPageLoad(NormalMode)
         }
       }
-      "NORMALMODE must go from the Using Mongo Page to Using Object Store page WHEN answer is NO" in {
-        val oldAnswers = UserAnswers("id")
+      "must go from the Using Mongo Page to Using Object Store page WHEN answer is NO" in {
         UserAnswers("id").set(UsingMongoPage, false).foreach { userAnswers =>
-          navigator.nextPage(UsingMongoPage, NormalMode, userAnswers, oldAnswers) mustBe dataPersistenceRoutes.UsingObjectStoreController.onPageLoad(NormalMode)
+          navigator.nextPage(UsingMongoPage, NormalMode, userAnswers) mustBe dataPersistenceRoutes.UsingObjectStoreController.onPageLoad(NormalMode)
         }
       }
       "must go from the Resilient Recycling Mongo page to the Public Mongo TTL page" in {
-        val oldAnswers = UserAnswers("id")
-        navigator.nextPage(ResilientRecycleMongoPage, NormalMode, UserAnswers("id"), oldAnswers) mustBe dataPersistenceRoutes.PublicMongoTTLController.onPageLoad(NormalMode)
+        navigator.nextPage(ResilientRecycleMongoPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.PublicMongoTTLController.onPageLoad(NormalMode)
       }
       "must go from the Public Mongo TTL page to the Field Level Encryption page" in {
-        val oldAnswers = UserAnswers("id")
-        navigator.nextPage(PublicMongoTTLPage, NormalMode, UserAnswers("id"), oldAnswers) mustBe dataPersistenceRoutes.FieldLevelEncryptionController.onPageLoad(NormalMode)
+        navigator.nextPage(PublicMongoTTLPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.FieldLevelEncryptionController.onPageLoad(NormalMode)
       }
       "must go from the Field Level Encryption page to the Protected Mongo TTL page" in {
-        val oldAnswers = UserAnswers("id")
-        navigator.nextPage(FieldLevelEncryptionPage, NormalMode, UserAnswers("id"), oldAnswers) mustBe dataPersistenceRoutes.ProtectedMongoTTLController.onPageLoad(NormalMode)
+        navigator.nextPage(FieldLevelEncryptionPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.ProtectedMongoTTLController.onPageLoad(NormalMode)
       }
       "must go from the Protected Mongo TTL page to the Mongo Tested With Indexing page" in {
-        val oldAnswers = UserAnswers("id")
-        navigator.nextPage(ProtectedMongoTTLPage, NormalMode, UserAnswers("id"), oldAnswers) mustBe dataPersistenceRoutes.MongoTestedWithIndexingController.onPageLoad(NormalMode)
+        navigator.nextPage(ProtectedMongoTTLPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.MongoTestedWithIndexingController.onPageLoad(NormalMode)
       }
       "must go from the Mongo Tested With Indexing page to the Using Object Store page" in {
-        val oldAnswers = UserAnswers("id")
-        navigator.nextPage(MongoTestedWithIndexingPage, NormalMode, UserAnswers("id"), oldAnswers) mustBe dataPersistenceRoutes.UsingObjectStoreController.onPageLoad(NormalMode)
+        navigator.nextPage(MongoTestedWithIndexingPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.UsingObjectStoreController.onPageLoad(NormalMode)
       }
-      "NORMALMODE must go from the Using Object Store page to Correct Retention Period page WHEN answer is YES" in {
-        val oldAnswers = UserAnswers("id")
+      "must go from the Using Object Store page to Correct Retention Period page WHEN answer is YES" in {
         UserAnswers("id").set(UsingObjectStorePage, true).foreach { userAnswers =>
-          navigator.nextPage(UsingObjectStorePage, NormalMode, userAnswers, oldAnswers) mustBe dataPersistenceRoutes.CorrectRetentionPeriodController.onPageLoad(NormalMode)
+          navigator.nextPage(UsingObjectStorePage, NormalMode, userAnswers) mustBe dataPersistenceRoutes.CorrectRetentionPeriodController.onPageLoad(NormalMode)
         }
       }
-      "NORMALMODE must go from the Using Object Store page to Check Your Answers page WHEN answer is NO" in {
-        val oldAnswers = UserAnswers("id")
+      "must go from the Using Object Store page to Check Your Answers page WHEN answer is NO" in {
         UserAnswers("id").set(UsingObjectStorePage, false).foreach { userAnswers =>
-          navigator.nextPage(UsingObjectStorePage, NormalMode, userAnswers, oldAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+          navigator.nextPage(UsingObjectStorePage, NormalMode, userAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
         }
       }
       "must go from the Correct Retention Period page to the Check Your Answers page" in {
-        val oldAnswers = UserAnswers("id")
-        navigator.nextPage(CorrectRetentionPeriodPage, NormalMode, UserAnswers("id"), oldAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+        navigator.nextPage(CorrectRetentionPeriodPage, NormalMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
       }
     }
 
     "in Check mode" - {
 
-      "CHECKMODE must go from the Using Mongo page to the Resilient Recycling Mongo WHEN answer is From NO to YES when oldAnswer was NO" in {
-        UserAnswers("id").set(UsingMongoPage, false).foreach { oldAnswers =>
-          UserAnswers("id").set(UsingMongoPage, true).foreach { userAnswers =>
-            navigator.nextPage(UsingMongoPage, CheckMode, userAnswers, oldAnswers) mustBe dataPersistenceRoutes.ResilientRecycleMongoController.onPageLoad(NormalMode)
-          }
+      "must go from the Using Mongo page to the Resilient Recycling Mongo WHEN answer is YES AND Resilient Recycling Mongo does not have an Answer" in {
+        UserAnswers("id").set(UsingMongoPage, true).foreach { userAnswers =>
+          navigator.nextPage(UsingMongoPage, CheckMode, userAnswers) mustBe dataPersistenceRoutes.ResilientRecycleMongoController.onPageLoad(CheckMode)
         }
       }
-      "CHECKMODE must go from the Using Mongo Page to Check Your Answers page WHEN answer is from YES to NO when oldAnswer was YES" in {
-        UserAnswers("id").set(UsingMongoPage, true).foreach { oldAnswers =>
-          UserAnswers("id").set(UsingMongoPage, false).foreach { userAnswers =>
-            navigator.nextPage(UsingMongoPage, CheckMode, userAnswers, oldAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+      "must go from the Using Mongo Page to Check Your Answers page WHEN answer is Yes AND Resilient Recycling Mongo has an Answer " in {
+        val updatedUserAnswers = for {
+          withMongo <- UserAnswers("id").set(UsingMongoPage, true)
+          withResilient <- withMongo.set(ResilientRecycleMongoPage, true)
+        } yield withResilient
+
+        updatedUserAnswers.foreach { userAnswers =>
+            navigator.nextPage(UsingMongoPage, CheckMode, userAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
           }
+      }
+      "must go from the Using Mongo Page to Check Your Answers page WHEN answer is NO AND Resilient Recycle Mongo has an Answer" in {
+        val updatedUserAnswers = for {
+          withMongo <- UserAnswers("id").set(UsingMongoPage, false)
+          withResilient <- withMongo.set(ResilientRecycleMongoPage, true)
+        } yield withResilient
+
+        updatedUserAnswers.foreach { userAnswers =>
+          navigator.nextPage(UsingMongoPage, CheckMode, userAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
         }
       }
-      "CHECKMODE must go from the Using Mongo Page to Check Your Answers page WHEN answer is from YES to YES when oldAnswer was YES" in {
-        UserAnswers("id").set(UsingMongoPage, true).foreach { oldAnswers =>
-          UserAnswers("id").set(UsingMongoPage, true).foreach { userAnswers =>
-            navigator.nextPage(UsingMongoPage, CheckMode, userAnswers, oldAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-          }
+
+      "must go from Resilient Recycling Mongo to Public Mongo TTL WHEN Public Mongo TTL does not have an answer" in {
+        navigator.nextPage(ResilientRecycleMongoPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.PublicMongoTTLController.onPageLoad(CheckMode)
+      }
+      "must go from the Resilient Recycling Mongo page to the Check Your Answers page WHEN Public Mongo TTL has an Answer" in {
+        UserAnswers("id").set(PublicMongoTTLPage, true).foreach { userAnswers =>
+          navigator.nextPage(ResilientRecycleMongoPage, CheckMode, userAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
         }
       }
-      "CHECKMODE must go from the Using Mongo Page to Check Your Answers page WHEN answer is from NO to NO when oldAnswer was NO" in {
-        UserAnswers("id").set(UsingMongoPage, false).foreach { oldAnswers =>
-          UserAnswers("id").set(UsingMongoPage, false).foreach { userAnswers =>
-            navigator.nextPage(UsingMongoPage, CheckMode, userAnswers, oldAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
-          }
+
+      "must go from the Public Mongo TTL page to the Check Your Answers page WHEN Field Level Encryption does not have an answer" in {
+        navigator.nextPage(PublicMongoTTLPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.FieldLevelEncryptionController.onPageLoad(CheckMode)
+      }
+      "must go from the Public Mongo TTL page to the Check Your Answers page WHEN Field Level Encryption has an Answer" in {
+        UserAnswers("id").set(FieldLevelEncryptionPage, true).foreach { userAnswers =>
+          navigator.nextPage(PublicMongoTTLPage, CheckMode, userAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
         }
       }
-      "must go from the Resilient Recycling Mongo page to the Check Your Answers page" in {
-        val oldAnswers = UserAnswers("id")
-        navigator.nextPage(ResilientRecycleMongoPage, CheckMode, UserAnswers("id"), oldAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+
+      "must go from the Field Level Encryption page to the Protected Mongo page WHEN Protected Mongo does not have an Answer" in {
+        navigator.nextPage(FieldLevelEncryptionPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.ProtectedMongoTTLController.onPageLoad(CheckMode)
       }
-      "must go from the Public Mongo TTL page to the Check Your Answers page" in {
-        val oldAnswers = UserAnswers("id")
-        navigator.nextPage(PublicMongoTTLPage, CheckMode, UserAnswers("id"), oldAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+      "must go from the Field Level Encryption page to the Check Your Answers page WHEN Protected Mongo has an Answer" in {
+        UserAnswers("id").set(ProtectedMongoTTLPage, true).foreach { userAnswers =>
+          navigator.nextPage(FieldLevelEncryptionPage, CheckMode, userAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+        }
       }
-      "must go from the Field Level Encryption page to the Check Your Answers page" in {
-        val oldAnswers = UserAnswers("id")
-        navigator.nextPage(FieldLevelEncryptionPage, CheckMode, UserAnswers("id"), oldAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+
+      "must go from the Protected Mongo TTL page to the Mongo Tested With Indexing page WHEN Mongo Tested With Indexing does not have an Answer" in {
+        navigator.nextPage(ProtectedMongoTTLPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.MongoTestedWithIndexingController.onPageLoad(CheckMode)
       }
-      "must go from the Protected Mongo TTL page to the Check Your Answers page" in {
-        val oldAnswers = UserAnswers("id")
-        navigator.nextPage(ProtectedMongoTTLPage, CheckMode, UserAnswers("id"), oldAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+      "must go from the Protected Mongo TTL page to the Check Your Answers page WHEN Mongo Tested With Indexing has an Answer" in {
+        UserAnswers("id").set(MongoTestedWithIndexingPage, true).foreach { userAnswers =>
+          navigator.nextPage(ProtectedMongoTTLPage, CheckMode, userAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+        }
       }
+
       "must go from the Mongo Tested With Indexing page to the Check Your Answers page" in {
-        val oldAnswers = UserAnswers("id")
-        navigator.nextPage(MongoTestedWithIndexingPage, CheckMode, UserAnswers("id"), oldAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+        navigator.nextPage(MongoTestedWithIndexingPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
       }
-      "CHECKMODE must go from the Using Object Store page to Correct Retention Period page WHEN answer is YES" in {
-        val oldAnswers = UserAnswers("id")
+
+      "must go from the Using Object Store page to Correct Retention Period page WHEN answer is YES AND Correct Retention Period does not have an Answer" in {
         UserAnswers("id").set(UsingObjectStorePage, true).foreach { userAnswers =>
-          navigator.nextPage(UsingObjectStorePage, CheckMode, userAnswers, oldAnswers) mustBe dataPersistenceRoutes.CorrectRetentionPeriodController.onPageLoad(CheckMode)
+          navigator.nextPage(UsingObjectStorePage, CheckMode, userAnswers) mustBe dataPersistenceRoutes.CorrectRetentionPeriodController.onPageLoad(CheckMode)
         }
       }
-      "CHECKMODE must go from the Using Object Store page to Check Your Answers page WHEN answer is NO" in {
-        val oldAnswers = UserAnswers("id")
-        UserAnswers("id").set(UsingObjectStorePage, false).foreach { userAnswers =>
-          navigator.nextPage(UsingObjectStorePage, CheckMode, userAnswers, oldAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+      "must go from the Using Object Store page to Check Your Answers page WHEN answer is YES WHEN Correct Retention Period has an Answer" in {
+        val updatedUserAnswers = for {
+          withObject <- UserAnswers("id").set(UsingObjectStorePage, true)
+          withRetention <- withObject.set(CorrectRetentionPeriodPage, true)
+        } yield withRetention
+
+        updatedUserAnswers.foreach { userAnswers =>
+          navigator.nextPage(UsingMongoPage, CheckMode, userAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
         }
       }
+      "must go from the Using Object Store page to Check Your Answers page WHEN answer is NO WHEN Correct Retention Period has an Answer" in {
+        val updatedUserAnswers = for {
+          withObject <- UserAnswers("id").set(UsingObjectStorePage, false)
+          withRetention <- withObject.set(CorrectRetentionPeriodPage, true)
+        } yield withRetention
+
+        updatedUserAnswers.foreach { userAnswers =>
+          navigator.nextPage(UsingMongoPage, CheckMode, userAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+        }
+      }
+
       "must go from the Correct Retention Period page to the Check Your Answers page" in {
-        val oldAnswers = UserAnswers("id")
-        navigator.nextPage(CorrectRetentionPeriodPage, CheckMode, UserAnswers("id"), oldAnswers) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
+        navigator.nextPage(CorrectRetentionPeriodPage, CheckMode, UserAnswers("id")) mustBe dataPersistenceRoutes.CheckYourAnswersController.onPageLoad()
       }
 
       "must go from a page that doesn't exist in the edit route map to CheckYourAnswers" in {
-        val oldAnswers = UserAnswers("id")
         case object UnknownPage extends Page
-        navigator.nextPage(UnknownPage, CheckMode, UserAnswers("id"), oldAnswers) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
+        navigator.nextPage(UnknownPage, CheckMode, UserAnswers("id")) mustBe securityRoutes.CheckYourAnswersController.onPageLoad()
       }
     }
   }

--- a/test/navigation/FakeDataPersistenceNavigator.scala
+++ b/test/navigation/FakeDataPersistenceNavigator.scala
@@ -22,6 +22,6 @@ import play.api.mvc.Call
 
 class FakeDataPersistenceNavigator(desiredRoute: Call) extends DataPersistenceNavigator {
 
-  override def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers, oldAnswers: UserAnswers): Call =
+  override def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers): Call =
     desiredRoute
 }

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -19,13 +19,10 @@ package navigation
 import base.SpecBase
 import controllers.routes
 import controllers.buildResilience.routes as buildResilienceRoutes
-import controllers.dataPersistence.routes as dataPersistenceRoutes
 import controllers.security.routes as securityRoutes
 import models.*
 import pages.*
 import pages.buildResilience.{AppropriateTimeoutsPage, BreakBobbyRulesPage, DeprecatedLibrariesPage, DoesNonstandardPatternPage, NonstandardPatternPage, ReadMeFitForPurposePage, ServiceURLPage, UsingHTTPVerbsPage}
-import pages.dataPersistence.{CorrectRetentionPeriodPage, FieldLevelEncryptionPage, MongoTestedWithIndexingPage, ProtectedMongoTTLPage, PublicMongoTTLPage, ResilientRecycleMongoPage, UsingMongoPage, UsingObjectStorePage}
-
 class NavigatorSpec extends SpecBase {
 
   val navigator = new Navigator

--- a/test/pages/dataPersistence/UsingMongoPageSpec.scala
+++ b/test/pages/dataPersistence/UsingMongoPageSpec.scala
@@ -19,15 +19,11 @@ package pages.dataPersistence
 import base.SpecBase
 import models.UserAnswers
 
-import scala.util.Try
-
 class UsingMongoPageSpec extends SpecBase {
 
   "UsingMongoPage" - {
 
     "Must Clear Mongo Pages when answer is changed from YES to NO" in {
-      //step 1 data set up
-      //set up user answers which contains each mongo page
       val userAnswersWithMongoPages = for {
         withMongo <- UserAnswers("id").set(UsingMongoPage, true)
         withResilient <- withMongo.set(ResilientRecycleMongoPage, false)
@@ -37,13 +33,8 @@ class UsingMongoPageSpec extends SpecBase {
         withTestedIndex <- withProtected.set(MongoTestedWithIndexingPage, false)
       } yield withTestedIndex
 
-
-      //step 2 call code in test /trigger test
-      //
       val actual = userAnswersWithMongoPages.flatMap(_.set(UsingMongoPage, false))
 
-      //step 3 check outcome is expected
-      //
       actual.foreach(_.get(ResilientRecycleMongoPage) mustBe None)
       actual.foreach(_.get(PublicMongoTTLPage) mustBe None)
       actual.foreach(_.get(FieldLevelEncryptionPage) mustBe None)
@@ -52,8 +43,6 @@ class UsingMongoPageSpec extends SpecBase {
 
     }
     "Must Not Clear Mongo Pages when Answer is changed from NO to YES" in {
-      //step 1 data set up
-      //set up user answers which contains each mongo page
       val userAnswersWithMongoPages = for {
         withMongo <- UserAnswers("id").set(UsingMongoPage, false)
         withResilient <- withMongo.set(ResilientRecycleMongoPage, false)
@@ -63,13 +52,8 @@ class UsingMongoPageSpec extends SpecBase {
         withTestedIndex <- withProtected.set(MongoTestedWithIndexingPage, false)
       } yield withTestedIndex
 
-
-      //step 2 call code in test /trigger test
-      //
       val actual = userAnswersWithMongoPages.flatMap(_.set(UsingMongoPage, true))
 
-      //step 3 check outcome is expected
-      //
       actual.foreach(_.get(ResilientRecycleMongoPage) mustBe Some(false))
       actual.foreach(_.get(PublicMongoTTLPage) mustBe Some(false))
       actual.foreach(_.get(FieldLevelEncryptionPage) mustBe Some(false))
@@ -77,8 +61,6 @@ class UsingMongoPageSpec extends SpecBase {
       actual.foreach(_.get(MongoTestedWithIndexingPage) mustBe Some(false))
     }
     "Must Clear Mongo Pages when Answer is unchanged and Answer is NO" in {
-      //step 1 data set up
-      //set up user answers which contains each mongo page
       val userAnswersWithMongoPages = for {
         withMongo <- UserAnswers("id").set(UsingMongoPage, false)
         withResilient <- withMongo.set(ResilientRecycleMongoPage, false)
@@ -88,13 +70,8 @@ class UsingMongoPageSpec extends SpecBase {
         withTestedIndex <- withProtected.set(MongoTestedWithIndexingPage, false)
       } yield withTestedIndex
 
-
-      //step 2 call code in test /trigger test
-      //
       val actual = userAnswersWithMongoPages.flatMap(_.set(UsingMongoPage, false))
 
-      //step 3 check outcome is expected
-      //
       actual.foreach(_.get(ResilientRecycleMongoPage) mustBe None)
       actual.foreach(_.get(PublicMongoTTLPage) mustBe None)
       actual.foreach(_.get(FieldLevelEncryptionPage) mustBe None)
@@ -102,8 +79,6 @@ class UsingMongoPageSpec extends SpecBase {
       actual.foreach(_.get(MongoTestedWithIndexingPage) mustBe None)
     }
     "Must not do anything when Answer is unchanged and Answer is YES" in {
-      //step 1 data set up
-      //set up user answers which contains each mongo page
       val userAnswersWithMongoPages = for {
         withMongo <- UserAnswers("id").set(UsingMongoPage, true)
         withResilient <- withMongo.set(ResilientRecycleMongoPage, false)
@@ -113,13 +88,8 @@ class UsingMongoPageSpec extends SpecBase {
         withTestedIndex <- withProtected.set(MongoTestedWithIndexingPage, false)
       } yield withTestedIndex
 
-
-      //step 2 call code in test /trigger test
-      //
       val actual = userAnswersWithMongoPages.flatMap(_.set(UsingMongoPage, true))
 
-      //step 3 check outcome is expected
-      //
       actual.foreach(_.get(ResilientRecycleMongoPage) mustBe Some(false))
       actual.foreach(_.get(PublicMongoTTLPage) mustBe Some(false))
       actual.foreach(_.get(FieldLevelEncryptionPage) mustBe Some(false))
@@ -127,5 +97,4 @@ class UsingMongoPageSpec extends SpecBase {
       actual.foreach(_.get(MongoTestedWithIndexingPage) mustBe Some(false))
     }
   }
-
 }

--- a/test/pages/dataPersistence/UsingMongoPageSpec.scala
+++ b/test/pages/dataPersistence/UsingMongoPageSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.dataPersistence
+
+import base.SpecBase
+import models.UserAnswers
+
+import scala.util.Try
+
+class UsingMongoPageSpec extends SpecBase {
+
+  "UsingMongoPage" - {
+
+    "Must Clear Mongo Pages when answer is changed from YES to NO" in {
+      //step 1 data set up
+      //set up user answers which contains each mongo page
+      val userAnswersWithMongoPages = for {
+        withMongo <- UserAnswers("id").set(UsingMongoPage, true)
+        withResilient <- withMongo.set(ResilientRecycleMongoPage, false)
+        withPublic <- withResilient.set(PublicMongoTTLPage, false)
+        withField <- withPublic.set(FieldLevelEncryptionPage, false)
+        withProtected <- withField.set(ProtectedMongoTTLPage, false)
+        withTestedIndex <- withProtected.set(MongoTestedWithIndexingPage, false)
+      } yield withTestedIndex
+
+
+      //step 2 call code in test /trigger test
+      //
+      val actual = userAnswersWithMongoPages.flatMap(_.set(UsingMongoPage, false))
+
+      //step 3 check outcome is expected
+      //
+      actual.foreach(_.get(ResilientRecycleMongoPage) mustBe None)
+      actual.foreach(_.get(PublicMongoTTLPage) mustBe None)
+      actual.foreach(_.get(FieldLevelEncryptionPage) mustBe None)
+      actual.foreach(_.get(ProtectedMongoTTLPage) mustBe None)
+      actual.foreach(_.get(MongoTestedWithIndexingPage) mustBe None)
+
+    }
+    "Must Not Clear Mongo Pages when Answer is changed from NO to YES" in {
+      //step 1 data set up
+      //set up user answers which contains each mongo page
+      val userAnswersWithMongoPages = for {
+        withMongo <- UserAnswers("id").set(UsingMongoPage, false)
+        withResilient <- withMongo.set(ResilientRecycleMongoPage, false)
+        withPublic <- withResilient.set(PublicMongoTTLPage, false)
+        withField <- withPublic.set(FieldLevelEncryptionPage, false)
+        withProtected <- withField.set(ProtectedMongoTTLPage, false)
+        withTestedIndex <- withProtected.set(MongoTestedWithIndexingPage, false)
+      } yield withTestedIndex
+
+
+      //step 2 call code in test /trigger test
+      //
+      val actual = userAnswersWithMongoPages.flatMap(_.set(UsingMongoPage, true))
+
+      //step 3 check outcome is expected
+      //
+      actual.foreach(_.get(ResilientRecycleMongoPage) mustBe Some(false))
+      actual.foreach(_.get(PublicMongoTTLPage) mustBe Some(false))
+      actual.foreach(_.get(FieldLevelEncryptionPage) mustBe Some(false))
+      actual.foreach(_.get(ProtectedMongoTTLPage) mustBe Some(false))
+      actual.foreach(_.get(MongoTestedWithIndexingPage) mustBe Some(false))
+    }
+    "Must Clear Mongo Pages when Answer is unchanged and Answer is NO" in {
+      //step 1 data set up
+      //set up user answers which contains each mongo page
+      val userAnswersWithMongoPages = for {
+        withMongo <- UserAnswers("id").set(UsingMongoPage, false)
+        withResilient <- withMongo.set(ResilientRecycleMongoPage, false)
+        withPublic <- withResilient.set(PublicMongoTTLPage, false)
+        withField <- withPublic.set(FieldLevelEncryptionPage, false)
+        withProtected <- withField.set(ProtectedMongoTTLPage, false)
+        withTestedIndex <- withProtected.set(MongoTestedWithIndexingPage, false)
+      } yield withTestedIndex
+
+
+      //step 2 call code in test /trigger test
+      //
+      val actual = userAnswersWithMongoPages.flatMap(_.set(UsingMongoPage, false))
+
+      //step 3 check outcome is expected
+      //
+      actual.foreach(_.get(ResilientRecycleMongoPage) mustBe None)
+      actual.foreach(_.get(PublicMongoTTLPage) mustBe None)
+      actual.foreach(_.get(FieldLevelEncryptionPage) mustBe None)
+      actual.foreach(_.get(ProtectedMongoTTLPage) mustBe None)
+      actual.foreach(_.get(MongoTestedWithIndexingPage) mustBe None)
+    }
+    "Must not do anything when Answer is unchanged and Answer is YES" in {
+      //step 1 data set up
+      //set up user answers which contains each mongo page
+      val userAnswersWithMongoPages = for {
+        withMongo <- UserAnswers("id").set(UsingMongoPage, true)
+        withResilient <- withMongo.set(ResilientRecycleMongoPage, false)
+        withPublic <- withResilient.set(PublicMongoTTLPage, false)
+        withField <- withPublic.set(FieldLevelEncryptionPage, false)
+        withProtected <- withField.set(ProtectedMongoTTLPage, false)
+        withTestedIndex <- withProtected.set(MongoTestedWithIndexingPage, false)
+      } yield withTestedIndex
+
+
+      //step 2 call code in test /trigger test
+      //
+      val actual = userAnswersWithMongoPages.flatMap(_.set(UsingMongoPage, true))
+
+      //step 3 check outcome is expected
+      //
+      actual.foreach(_.get(ResilientRecycleMongoPage) mustBe Some(false))
+      actual.foreach(_.get(PublicMongoTTLPage) mustBe Some(false))
+      actual.foreach(_.get(FieldLevelEncryptionPage) mustBe Some(false))
+      actual.foreach(_.get(ProtectedMongoTTLPage) mustBe Some(false))
+      actual.foreach(_.get(MongoTestedWithIndexingPage) mustBe Some(false))
+    }
+  }
+
+}

--- a/test/pages/dataPersistence/UsingObjectStorePageSpec.scala
+++ b/test/pages/dataPersistence/UsingObjectStorePageSpec.scala
@@ -19,78 +19,48 @@ package pages.dataPersistence
 import base.SpecBase
 import models.UserAnswers
 
-import scala.util.Try
-
 class UsingObjectStorePageSpec extends SpecBase {
 
   "UsingObjectStorePage" - {
 
     "Must Clear Object Pages when answer is changed from YES to NO" in {
-      //step 1 data set up
-      //set up user answers which contains each mongo page
       val userAnswersWithObjectPages = for {
         withObject <- UserAnswers("id").set(UsingObjectStorePage, true)
         withRetention <- withObject.set(CorrectRetentionPeriodPage, false)
       } yield withRetention
 
-
-      //step 2 call code in test /trigger test
-      //
       val actual = userAnswersWithObjectPages.flatMap(_.set(UsingObjectStorePage, false))
 
-      //step 3 check outcome is expected
-      //
       actual.foreach(_.get(CorrectRetentionPeriodPage) mustBe None)
     }
     "Must Not Clear Object Pages when Answer is changed from NO to YES" in {
-      //step 1 data set up
-      //set up user answers which contains each mongo page
       val userAnswersWithObjectPages = for {
         withObject <- UserAnswers("id").set(UsingObjectStorePage, false)
         withRetention <- withObject.set(CorrectRetentionPeriodPage, false)
       } yield withRetention
 
-
-      //step 2 call code in test /trigger test
-      //
       val actual = userAnswersWithObjectPages.flatMap(_.set(UsingObjectStorePage, true))
 
-      //step 3 check outcome is expected
-      //
       actual.foreach(_.get(CorrectRetentionPeriodPage) mustBe Some(false))
     }
     "Must Clear Object Pages when Answer is unchanged and Answer is NO" in {
-      //step 1 data set up
-      //set up user answers which contains each mongo page
       val userAnswersWithObjectPages = for {
         withObject <- UserAnswers("id").set(UsingObjectStorePage, false)
         withRetention <- withObject.set(CorrectRetentionPeriodPage, false)
       } yield withRetention
 
-
-      //step 2 call code in test /trigger test
-      //
       val actual = userAnswersWithObjectPages.flatMap(_.set(UsingObjectStorePage, false))
 
-      //step 3 check outcome is expected
-      //
       actual.foreach(_.get(CorrectRetentionPeriodPage) mustBe None)
     }
     "Must not do anything when Answer is unchanged and Answer is YES" in {
-      //step 1 data set up
-      //set up user answers which contains each mongo page
       val userAnswersWithObjectPages = for {
         withObject <- UserAnswers("id").set(UsingObjectStorePage, true)
         withRetention <- withObject.set(CorrectRetentionPeriodPage, false)
       } yield withRetention
-
-
-      //step 2 call code in test /trigger test
-      //
+      
       val actual = userAnswersWithObjectPages.flatMap(_.set(UsingObjectStorePage, true))
-
-      //step 3 check outcome is expected
-      //
+      
       actual.foreach(_.get(CorrectRetentionPeriodPage) mustBe Some(false))
     }
   }

--- a/test/pages/dataPersistence/UsingObjectStorePageSpec.scala
+++ b/test/pages/dataPersistence/UsingObjectStorePageSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.dataPersistence
+
+import base.SpecBase
+import models.UserAnswers
+
+import scala.util.Try
+
+class UsingObjectStorePageSpec extends SpecBase {
+
+  "UsingObjectStorePage" - {
+
+    "Must Clear Object Pages when answer is changed from YES to NO" in {
+      //step 1 data set up
+      //set up user answers which contains each mongo page
+      val userAnswersWithObjectPages = for {
+        withObject <- UserAnswers("id").set(UsingObjectStorePage, true)
+        withRetention <- withObject.set(CorrectRetentionPeriodPage, false)
+      } yield withRetention
+
+
+      //step 2 call code in test /trigger test
+      //
+      val actual = userAnswersWithObjectPages.flatMap(_.set(UsingObjectStorePage, false))
+
+      //step 3 check outcome is expected
+      //
+      actual.foreach(_.get(CorrectRetentionPeriodPage) mustBe None)
+    }
+    "Must Not Clear Object Pages when Answer is changed from NO to YES" in {
+      //step 1 data set up
+      //set up user answers which contains each mongo page
+      val userAnswersWithObjectPages = for {
+        withObject <- UserAnswers("id").set(UsingObjectStorePage, false)
+        withRetention <- withObject.set(CorrectRetentionPeriodPage, false)
+      } yield withRetention
+
+
+      //step 2 call code in test /trigger test
+      //
+      val actual = userAnswersWithObjectPages.flatMap(_.set(UsingObjectStorePage, true))
+
+      //step 3 check outcome is expected
+      //
+      actual.foreach(_.get(CorrectRetentionPeriodPage) mustBe Some(false))
+    }
+    "Must Clear Object Pages when Answer is unchanged and Answer is NO" in {
+      //step 1 data set up
+      //set up user answers which contains each mongo page
+      val userAnswersWithObjectPages = for {
+        withObject <- UserAnswers("id").set(UsingObjectStorePage, false)
+        withRetention <- withObject.set(CorrectRetentionPeriodPage, false)
+      } yield withRetention
+
+
+      //step 2 call code in test /trigger test
+      //
+      val actual = userAnswersWithObjectPages.flatMap(_.set(UsingObjectStorePage, false))
+
+      //step 3 check outcome is expected
+      //
+      actual.foreach(_.get(CorrectRetentionPeriodPage) mustBe None)
+    }
+    "Must not do anything when Answer is unchanged and Answer is YES" in {
+      //step 1 data set up
+      //set up user answers which contains each mongo page
+      val userAnswersWithObjectPages = for {
+        withObject <- UserAnswers("id").set(UsingObjectStorePage, true)
+        withRetention <- withObject.set(CorrectRetentionPeriodPage, false)
+      } yield withRetention
+
+
+      //step 2 call code in test /trigger test
+      //
+      val actual = userAnswersWithObjectPages.flatMap(_.set(UsingObjectStorePage, true))
+
+      //step 3 check outcome is expected
+      //
+      actual.foreach(_.get(CorrectRetentionPeriodPage) mustBe Some(false))
+    }
+  }
+}


### PR DESCRIPTION
Removed OldAnswers as we have refactored the navigation to no longer re use the normal mode journey while in check mode, now the navigator checks if the next sequential page has an answer to decide if the user should end up on the next page or check your answers.

This is to account for the branching nature of the questions in this section, where it is possible to get to check your answers without answering all questions,  when editing your answer for `Using Mongo` or `Using Object Store`  from NO to YES, you will now be required to go through a CheckMode journey similar to the normal mode, but will prevent the user from answering a question twice, unless they specifically go into that questions change page.

Implemented a Clean up function to both `Using Mongo` and `Using Object Store` which whenever these questions are answered with NO their follow up questions will be cleared out of MongoDB to prevent unnecessary data storage