### PR TITLE
Refactor for branching Navigation for BuildResilience and implemented…

### DIFF
--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -30,11 +30,6 @@ import javax.inject.{Inject, Singleton}
 class Navigator @Inject()() {
 
   private val normalRoutes: Page => UserAnswers => Call = {
-    /*######################################################
-    
-                       BUILD & RESILIENCE
-    
-    #######################################################*/
 
     case IndexPage => _ => buildResilienceRoutes.ServiceURLController.onPageLoad(NormalMode)
 
@@ -63,30 +58,59 @@ class Navigator @Inject()() {
 
   private val checkRouteMap: Page => UserAnswers => Call = {
 
-    /*######################################################
-    
-                       BUILD & RESILIENCE
-    
-    #######################################################*/
-
-    case ServiceURLPage => _ => buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
-    
-    case DoesNonstandardPatternPage => userAnswers =>
-      userAnswers.get(DoesNonstandardPatternPage) match {
-        case Some(true) => buildResilienceRoutes.NonstandardPatternController.onPageLoad(CheckMode)
-        case _ => buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+    case ServiceURLPage => userAnswers =>
+      if (userAnswers.get(DoesNonstandardPatternPage).isEmpty) {
+        buildResilienceRoutes.DoesNonstandardPatternController.onPageLoad(CheckMode)
+      } else {
+        buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
       }
 
-    case NonstandardPatternPage => _ => buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+    case DoesNonstandardPatternPage => userAnswers =>
+      if (userAnswers.get(NonstandardPatternPage).isEmpty) {
+        if (userAnswers.get(DoesNonstandardPatternPage).contains(true)) {
+          buildResilienceRoutes.NonstandardPatternController.onPageLoad(CheckMode)
+        } else {
+          buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+        }
+      } else {
+        buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      }
 
-    case BreakBobbyRulesPage => _ => buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+    case NonstandardPatternPage => userAnswers =>
+      if (userAnswers.get(BreakBobbyRulesPage).isEmpty) {
+        buildResilienceRoutes.BreakBobbyRulesController.onPageLoad(CheckMode)
+      } else {
+        buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      }
 
-    case DeprecatedLibrariesPage => _ => buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+    case BreakBobbyRulesPage => userAnswers =>
+      if (userAnswers.get(DeprecatedLibrariesPage).isEmpty) {
+        buildResilienceRoutes.DeprecatedLibrariesController.onPageLoad(CheckMode)
+      } else {
+        buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      }
 
-    case UsingHTTPVerbsPage => _ => buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+    case DeprecatedLibrariesPage => userAnswers =>
+      if (userAnswers.get(UsingHTTPVerbsPage).isEmpty) {
+        buildResilienceRoutes.UsingHTTPVerbsController.onPageLoad(CheckMode)
+      } else {
+        buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      }
 
-    case ReadMeFitForPurposePage => _ => buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+    case UsingHTTPVerbsPage => userAnswers =>
+      if (userAnswers.get(ReadMeFitForPurposePage).isEmpty) {
+        buildResilienceRoutes.ReadMeFitForPurposeController.onPageLoad(CheckMode)
+      } else {
+        buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      }
 
+    case ReadMeFitForPurposePage => userAnswers =>
+      if (userAnswers.get(AppropriateTimeoutsPage).isEmpty) {
+        buildResilienceRoutes.AppropriateTimeoutsController.onPageLoad(CheckMode)
+      } else {
+        buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      }
+      
     case AppropriateTimeoutsPage => _ => buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
 
     case _ => _ => securityRoutes.CheckYourAnswersController.onPageLoad()

--- a/app/pages/buildResilience/DoesNonstandardPatternPage.scala
+++ b/app/pages/buildResilience/DoesNonstandardPatternPage.scala
@@ -16,12 +16,27 @@
 
 package pages.buildResilience
 
+import models.UserAnswers
 import pages.QuestionPage
 import play.api.libs.json.JsPath
+
+import scala.util.{Success, Try}
 
 case object DoesNonstandardPatternPage extends QuestionPage[Boolean] {
 
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "doesNonstandardPattern"
+
+  override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] = {
+
+    val nonStandardPages: List[QuestionPage[_]] = List(
+      NonstandardPatternPage
+    )
+
+    value match {
+      case Some(false) => userAnswers.removeList(nonStandardPages)
+      case _ => Success(userAnswers)
+    }
+  }
 }

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -44,13 +44,13 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(ServiceURLPage, NormalMode, UserAnswers("id")) mustBe buildResilienceRoutes.DoesNonstandardPatternController.onPageLoad(NormalMode)
       }
 
-      "NORMALMODE must go from the Does Include Non-standard Pattern page to the Which Non-standard Pattern page WHEN answer is YES" in {
+      "must go from the Does Include Non-standard Pattern page to the Which Non-standard Pattern page WHEN answer is YES" in {
         UserAnswers("id").set(DoesNonstandardPatternPage, true).foreach { userAnswers =>
           navigator.nextPage(DoesNonstandardPatternPage, NormalMode, userAnswers) mustBe buildResilienceRoutes.NonstandardPatternController.onPageLoad(NormalMode)
         }
       }
 
-      "NORMALMODE must go from the Does Include Non-standard Pattern Page to Break Bobby Rules page WHEN answer is NO" in {
+      "must go from the Does Include Non-standard Pattern Page to Break Bobby Rules page WHEN answer is NO" in {
         UserAnswers("id").set(DoesNonstandardPatternPage, false).foreach { userAnswers =>
           navigator.nextPage(DoesNonstandardPatternPage, NormalMode, userAnswers) mustBe buildResilienceRoutes.BreakBobbyRulesController.onPageLoad(NormalMode)
         }
@@ -83,40 +83,84 @@ class NavigatorSpec extends SpecBase {
 
     "in Check mode" - {
       
-      "must go from the Service URL page to the Check Your Answers page" in {
-        navigator.nextPage(ServiceURLPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      "must go from the Service URL page to the Does Nonstandard Pattern page WHEN Does Nonstandard Pattern Page does not have an Answer" in {
+        navigator.nextPage(ServiceURLPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.DoesNonstandardPatternController.onPageLoad(CheckMode)
+      }
+      "must go from the Service URL page to the Check Your Answers page WHEN Does Nonstandard Pattern has an Answer" in {
+        UserAnswers("id").set(DoesNonstandardPatternPage, true).foreach { userAnswers =>
+          navigator.nextPage(ServiceURLPage, CheckMode, userAnswers) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+        }
       }
 
-      "CHECKMODE must go from the Does Include Non-standard Pattern Page to Which Non-standard Patterns page WHEN answer is YES" in {
+      "must go from the Does Include Non-standard Pattern Page to Which Non-standard Patterns page WHEN answer is YES AND Non Standard Pattern Page does not have an Answer" in {
         UserAnswers("id").set(DoesNonstandardPatternPage, true).foreach { userAnswers =>
           navigator.nextPage(DoesNonstandardPatternPage, CheckMode, userAnswers) mustBe buildResilienceRoutes.NonstandardPatternController.onPageLoad(CheckMode)
         }
       }
+      "must go from the Does Include Non-standard Pattern Page to Check Your Answers page WHEN answer is Yes AND Non Standard Pattern Page has an Answer " in {
+        val updatedUserAnswers = for {
+          withDoesNonstandard <- UserAnswers("id").set(DoesNonstandardPatternPage, true)
+          withNonstandard <- withDoesNonstandard.set(NonstandardPatternPage, "true")
+        } yield withNonstandard
 
-      "CHECKMODE must go from the Does Include Non-standard Pattern Page to CheckYourAnswers page WHEN answer is NO" in {
-        UserAnswers("id").set(DoesNonstandardPatternPage, false).foreach { userAnswers =>
+        updatedUserAnswers.foreach { userAnswers =>
+          navigator.nextPage(DoesNonstandardPatternPage, CheckMode, userAnswers) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+        }
+      }
+      "must go from the Using Mongo Page to Check Your Answers page WHEN answer is NO AND Non Standard Pattern Page has an Answer" in {
+        val updatedUserAnswers = for {
+          withDoesNonstandard <- UserAnswers("id").set(DoesNonstandardPatternPage, false)
+          withNonstandard <- withDoesNonstandard.set(NonstandardPatternPage, "true")
+        } yield withNonstandard
+
+        updatedUserAnswers.foreach { userAnswers =>
           navigator.nextPage(DoesNonstandardPatternPage, CheckMode, userAnswers) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
         }
       }
 
-      "must go from the Which Non-standard Pattern page to the Check Your Answers page" in {
-        navigator.nextPage(NonstandardPatternPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      "must go from the Which Non-standard Pattern page to the Break Bobby Rules page WHEN Break Bobby Rules Page does not have an Answer" in {
+        navigator.nextPage(NonstandardPatternPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.BreakBobbyRulesController.onPageLoad(CheckMode)
+      }
+      "must go from the Which Non-standard Pattern page to the Check Your Answers page WHEN Break Bobby Rules Page has an Answer" in {
+        UserAnswers("id").set(BreakBobbyRulesPage, true).foreach { userAnswers =>
+          navigator.nextPage(NonstandardPatternPage, CheckMode, userAnswers) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+        }
       }
 
-      "must go from the Bobby Rules page to the Check Your Answers page" in {
-        navigator.nextPage(BreakBobbyRulesPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      "must go from the Break Bobby Rules page to the Deprecated HMRC Libraries page WHEN Deprecated HMRC Libraries Page does not have an Answer" in {
+        navigator.nextPage(BreakBobbyRulesPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.DeprecatedLibrariesController.onPageLoad(CheckMode)
+      }
+      "must go from the Which Non-standard Pattern page to the Check Your Answers page WHEN Deprecated HMRC Libraries Page has an Answer" in {
+        UserAnswers("id").set(DeprecatedLibrariesPage, true).foreach { userAnswers =>
+          navigator.nextPage(BreakBobbyRulesPage, CheckMode, userAnswers) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+        }
       }
 
-      "must go from the Deprecated HMRC Libraries page to the Check Your Answers page" in {
-        navigator.nextPage(DeprecatedLibrariesPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      "must go from the Deprecated HMRC Libraries page to the HTTP Verbs page WHEN HTTP Verbs Page does not have an Answer" in {
+        navigator.nextPage(DeprecatedLibrariesPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.UsingHTTPVerbsController.onPageLoad(CheckMode)
+      }
+      "must go from the Deprecated HMRC Libraries page to the Check Your Answers page WHEN HTTP Verbs Page has an Answer" in {
+        UserAnswers("id").set(UsingHTTPVerbsPage, true).foreach { userAnswers =>
+          navigator.nextPage(DeprecatedLibrariesPage, CheckMode, userAnswers) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+        }
       }
 
-      "must go from the HTTP Verbs page to the Check Your Answers page" in {
-        navigator.nextPage(UsingHTTPVerbsPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      "must go from the HTTP Verbs page to the ReadME Up-To-Date page WHEN ReadME Up-To-Date Page does not have an Answer" in {
+        navigator.nextPage(UsingHTTPVerbsPage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.ReadMeFitForPurposeController.onPageLoad(CheckMode)
+      }
+      "must go from the HTTP Verbs page to the Check Your Answers page WHEN ReadME Up-To-Date Page has an Answer" in {
+        UserAnswers("id").set(ReadMeFitForPurposePage, true).foreach { userAnswers =>
+          navigator.nextPage(UsingHTTPVerbsPage, CheckMode, userAnswers) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+        }
       }
 
-      "must go from the ReadME Up-To-Date and fit for purpose page to the Check Your Answers page" in {
-        navigator.nextPage(ReadMeFitForPurposePage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+      "must go from the ReadME Up-To-Date page to the Appropriate Timeouts page WHEN Appropriate Timeouts Page does not have an Answer" in {
+        navigator.nextPage(ReadMeFitForPurposePage, CheckMode, UserAnswers("id")) mustBe buildResilienceRoutes.AppropriateTimeoutsController.onPageLoad(CheckMode)
+      }
+      "must go from the ReadME Up-To-Date page to the Check Your Answers page WHEN ReadME Up-To-Date Page has an Answer" in {
+        UserAnswers("id").set(AppropriateTimeoutsPage, true).foreach { userAnswers =>
+          navigator.nextPage(ReadMeFitForPurposePage, CheckMode, userAnswers) mustBe buildResilienceRoutes.CheckYourAnswersController.onPageLoad()
+        }
       }
 
       "must go from the Appropriate Timeouts page to the Check Your Answers page" in {

--- a/test/pages/buildResilience/DoesNonstandardPatternPageSpec.scala
+++ b/test/pages/buildResilience/DoesNonstandardPatternPageSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.buildResilience
+
+import base.SpecBase
+import models.UserAnswers
+
+class DoesNonstandardPatternPageSpec extends SpecBase {
+
+  "DoesNonstandardPatternPage" - {
+
+    "Must Clear Nonstandard Pages when answer is changed from YES to NO" in {
+      val userAnswersWithNonstandardPages = for {
+        withDoesNonstandard <- UserAnswers("id").set(DoesNonstandardPatternPage, true)
+        withNonstandard <- withDoesNonstandard.set(NonstandardPatternPage, "false")
+      } yield withNonstandard
+
+      val actual = userAnswersWithNonstandardPages.flatMap(_.set(DoesNonstandardPatternPage, false))
+
+      actual.foreach(_.get(NonstandardPatternPage) mustBe None)
+    }
+    "Must Not Clear Nonstandard Pages when Answer is changed from NO to YES" in {
+      val userAnswersWithNonstandardPages = for {
+        withDoesNonstandard <- UserAnswers("id").set(DoesNonstandardPatternPage, false)
+        withNonstandard <- withDoesNonstandard.set(NonstandardPatternPage, "false")
+      } yield withNonstandard
+
+      val actual = userAnswersWithNonstandardPages.flatMap(_.set(DoesNonstandardPatternPage, true))
+
+      actual.foreach(_.get(NonstandardPatternPage) mustBe Some("false"))
+    }
+    "Must Clear Nonstandard Pages when Answer is unchanged and Answer is NO" in {
+      val userAnswersWithNonstandardPages = for {
+        withDoesNonstandard <- UserAnswers("id").set(DoesNonstandardPatternPage, false)
+        withNonstandard <- withDoesNonstandard.set(NonstandardPatternPage, "false")
+      } yield withNonstandard
+
+      val actual = userAnswersWithNonstandardPages.flatMap(_.set(DoesNonstandardPatternPage, false))
+
+      actual.foreach(_.get(NonstandardPatternPage) mustBe None)
+    }
+    "Must not do anything when Answer is unchanged and Answer is YES" in {
+      val userAnswersWithNonstandardPages = for {
+        withDoesNonstandard <- UserAnswers("id").set(DoesNonstandardPatternPage, true)
+        withNonstandard <- withDoesNonstandard.set(NonstandardPatternPage, "false")
+      } yield withNonstandard
+
+      val actual = userAnswersWithNonstandardPages.flatMap(_.set(DoesNonstandardPatternPage, true))
+
+      actual.foreach(_.get(NonstandardPatternPage) mustBe Some("false"))
+    }
+  }
+  
+}


### PR DESCRIPTION
… CleanUp

Similarly to #31, there is a refactor of the navigator for section 1: Build & Resilience's CheckMode, meaning that there is no way to skip questions which are 100% required. 

CleanUp has also been added for the `/does-nonstandard-pattern` & `/which-nonstandard-pattern` to prevent unnecessary data handling if `/does-nonstandard-pattern` is answered NO 