### PR TITLE
Admin services section

### DIFF
--- a/app/controllers/adminServices/AccessProductionAdminFrontendController.scala
+++ b/app/controllers/adminServices/AccessProductionAdminFrontendController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.adminServices
+
+import controllers.actions._
+import forms.adminServices.AccessProductionAdminFrontendFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.adminServices.AccessProductionAdminFrontendPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.adminServices.AccessProductionAdminFrontendView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AccessProductionAdminFrontendController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionService: SessionService,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: AccessProductionAdminFrontendFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: AccessProductionAdminFrontendView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(AccessProductionAdminFrontendPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(AccessProductionAdminFrontendPage, value))
+            _              <- sessionService.setUserAnswers(updatedAnswers)
+          } yield Redirect(navigator.nextPage(AccessProductionAdminFrontendPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/adminServices/AccessProductionAdminFrontendController.scala
+++ b/app/controllers/adminServices/AccessProductionAdminFrontendController.scala
@@ -20,7 +20,7 @@ import controllers.actions._
 import forms.adminServices.AccessProductionAdminFrontendFormProvider
 import javax.inject.Inject
 import models.Mode
-import navigation.Navigator
+import navigation.AdminServicesNavigator
 import pages.adminServices.AccessProductionAdminFrontendPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class AccessProductionAdminFrontendController @Inject()(
                                          override val messagesApi: MessagesApi,
                                          sessionService: SessionService,
-                                         navigator: Navigator,
+                                         navigator: AdminServicesNavigator,
                                          identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,

--- a/app/controllers/adminServices/CheckYourAnswersController.scala
+++ b/app/controllers/adminServices/CheckYourAnswersController.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.adminServices
+
+import com.google.inject.Inject
+import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierAction}
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import viewmodels.checkAnswers.adminServices.*
+import viewmodels.govuk.summarylist.*
+import views.html.adminServices.CheckYourAnswersView
+
+class CheckYourAnswersController @Inject()(
+                                            override val messagesApi: MessagesApi,
+                                            identify: IdentifierAction,
+                                            getData: DataRetrievalAction,
+                                            requireData: DataRequiredAction,
+                                            val controllerComponents: MessagesControllerComponents,
+                                            view: CheckYourAnswersView
+                                          ) extends FrontendBaseController with I18nSupport {
+
+  def onPageLoad(): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+      
+      val list = SummaryListViewModel(
+        rows = Seq(NoPublicRouteSummary.row(request.userAnswers),
+          StrideOrVPNSummary.row(request.userAnswers),
+          StrideOrInternalAuthSummary.row(request.userAnswers),
+          AccessProductionAdminFrontendSummary.row(request.userAnswers)
+        ).flatten
+      )
+
+      Ok(view(list))
+
+  }
+}

--- a/app/controllers/adminServices/NoPublicRouteController.scala
+++ b/app/controllers/adminServices/NoPublicRouteController.scala
@@ -20,7 +20,7 @@ import controllers.actions._
 import forms.adminServices.NoPublicRouteFormProvider
 import javax.inject.Inject
 import models.Mode
-import navigation.Navigator
+import navigation.AdminServicesNavigator
 import pages.adminServices.NoPublicRoutePage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class NoPublicRouteController @Inject()(
                                          override val messagesApi: MessagesApi,
                                          sessionService: SessionService,
-                                         navigator: Navigator,
+                                         navigator: AdminServicesNavigator,
                                          identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,

--- a/app/controllers/adminServices/NoPublicRouteController.scala
+++ b/app/controllers/adminServices/NoPublicRouteController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.adminServices
+
+import controllers.actions._
+import forms.adminServices.NoPublicRouteFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.adminServices.NoPublicRoutePage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.adminServices.NoPublicRouteView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class NoPublicRouteController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionService: SessionService,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: NoPublicRouteFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: NoPublicRouteView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(NoPublicRoutePage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(NoPublicRoutePage, value))
+            _              <- sessionService.setUserAnswers(updatedAnswers)
+          } yield Redirect(navigator.nextPage(NoPublicRoutePage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/adminServices/StrideOrInternalAuthController.scala
+++ b/app/controllers/adminServices/StrideOrInternalAuthController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.adminServices
+
+import controllers.actions._
+import forms.adminServices.StrideOrInternalAuthFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.adminServices.StrideOrInternalAuthPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.adminServices.StrideOrInternalAuthView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class StrideOrInternalAuthController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionService: SessionService,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: StrideOrInternalAuthFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: StrideOrInternalAuthView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(StrideOrInternalAuthPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(StrideOrInternalAuthPage, value))
+            _              <- sessionService.setUserAnswers(updatedAnswers)
+          } yield Redirect(navigator.nextPage(StrideOrInternalAuthPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/adminServices/StrideOrInternalAuthController.scala
+++ b/app/controllers/adminServices/StrideOrInternalAuthController.scala
@@ -20,7 +20,7 @@ import controllers.actions._
 import forms.adminServices.StrideOrInternalAuthFormProvider
 import javax.inject.Inject
 import models.Mode
-import navigation.Navigator
+import navigation.AdminServicesNavigator
 import pages.adminServices.StrideOrInternalAuthPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class StrideOrInternalAuthController @Inject()(
                                          override val messagesApi: MessagesApi,
                                          sessionService: SessionService,
-                                         navigator: Navigator,
+                                         navigator: AdminServicesNavigator,
                                          identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,

--- a/app/controllers/adminServices/StrideOrVPNController.scala
+++ b/app/controllers/adminServices/StrideOrVPNController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.adminServices
+
+import controllers.actions._
+import forms.adminServices.StrideOrVPNFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.adminServices.StrideOrVPNPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SessionService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.adminServices.StrideOrVPNView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class StrideOrVPNController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionService: SessionService,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: StrideOrVPNFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: StrideOrVPNView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(StrideOrVPNPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(StrideOrVPNPage, value))
+            _              <- sessionService.setUserAnswers(updatedAnswers)
+          } yield Redirect(navigator.nextPage(StrideOrVPNPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/adminServices/StrideOrVPNController.scala
+++ b/app/controllers/adminServices/StrideOrVPNController.scala
@@ -20,7 +20,7 @@ import controllers.actions._
 import forms.adminServices.StrideOrVPNFormProvider
 import javax.inject.Inject
 import models.Mode
-import navigation.Navigator
+import navigation.AdminServicesNavigator
 import pages.adminServices.StrideOrVPNPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class StrideOrVPNController @Inject()(
                                          override val messagesApi: MessagesApi,
                                          sessionService: SessionService,
-                                         navigator: Navigator,
+                                         navigator: AdminServicesNavigator,
                                          identify: IdentifierAction,
                                          getData: DataRetrievalAction,
                                          requireData: DataRequiredAction,

--- a/app/forms/adminServices/AccessProductionAdminFrontendFormProvider.scala
+++ b/app/forms/adminServices/AccessProductionAdminFrontendFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.adminServices
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class AccessProductionAdminFrontendFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("accessProductionAdminFrontend.error.required")
+    )
+}

--- a/app/forms/adminServices/NoPublicRouteFormProvider.scala
+++ b/app/forms/adminServices/NoPublicRouteFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.adminServices
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class NoPublicRouteFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("noPublicRoute.error.required")
+    )
+}

--- a/app/forms/adminServices/StrideOrInternalAuthFormProvider.scala
+++ b/app/forms/adminServices/StrideOrInternalAuthFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.adminServices
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class StrideOrInternalAuthFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("strideOrInternalAuth.error.required")
+    )
+}

--- a/app/forms/adminServices/StrideOrVPNFormProvider.scala
+++ b/app/forms/adminServices/StrideOrVPNFormProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.adminServices
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class StrideOrVPNFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("strideOrVPN.error.required")
+    )
+}

--- a/app/navigation/AdminServicesNavigator.scala
+++ b/app/navigation/AdminServicesNavigator.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package navigation
+
+import controllers.adminServices.routes as adminServicesRoutes
+import controllers.routes
+import models.*
+import pages.*
+import pages.adminServices.*
+import play.api.mvc.Call
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class AdminServicesNavigator @Inject() {
+
+  private val normalRoutes: Page => UserAnswers => Call = {
+    
+    case NoPublicRoutePage => _ => adminServicesRoutes.StrideOrVPNController.onPageLoad(NormalMode)
+
+    case StrideOrVPNPage => _ => adminServicesRoutes.StrideOrInternalAuthController.onPageLoad(NormalMode)
+
+    case StrideOrInternalAuthPage => _ => adminServicesRoutes.AccessProductionAdminFrontendController.onPageLoad(NormalMode)
+
+    case AccessProductionAdminFrontendPage => _ => adminServicesRoutes.CheckYourAnswersController.onPageLoad()
+
+    case _ => _ => routes.IndexController.onPageLoad()
+      
+  }
+
+  private val checkRouteMap: Page => UserAnswers => Call = {
+
+    case NoPublicRoutePage => userAnswers =>
+      if (userAnswers.get(StrideOrVPNPage).isEmpty) {
+        adminServicesRoutes.StrideOrVPNController.onPageLoad(CheckMode)
+      } else {
+        adminServicesRoutes.CheckYourAnswersController.onPageLoad()
+      }
+
+    case StrideOrVPNPage => userAnswers =>
+      if (userAnswers.get(StrideOrInternalAuthPage).isEmpty) {
+        adminServicesRoutes.StrideOrInternalAuthController.onPageLoad(CheckMode)
+      } else {
+        adminServicesRoutes.CheckYourAnswersController.onPageLoad()
+      }
+
+    case StrideOrInternalAuthPage => userAnswers =>
+      if (userAnswers.get(AccessProductionAdminFrontendPage).isEmpty) {
+        adminServicesRoutes.AccessProductionAdminFrontendController.onPageLoad(CheckMode)
+      } else {
+        adminServicesRoutes.CheckYourAnswersController.onPageLoad()
+      }
+
+    case _ => _ => adminServicesRoutes.CheckYourAnswersController.onPageLoad()
+      
+  }
+
+  def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers): Call = mode match {
+    case NormalMode =>
+      normalRoutes(page)(userAnswers)
+    case CheckMode =>
+      checkRouteMap(page)(userAnswers)
+  }
+}

--- a/app/pages/adminServices/AccessProductionAdminFrontendPage.scala
+++ b/app/pages/adminServices/AccessProductionAdminFrontendPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.adminServices
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object AccessProductionAdminFrontendPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "accessProductionAdminFrontend"
+}

--- a/app/pages/adminServices/NoPublicRoutePage.scala
+++ b/app/pages/adminServices/NoPublicRoutePage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.adminServices
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object NoPublicRoutePage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "noPublicRoute"
+}

--- a/app/pages/adminServices/StrideOrInternalAuthPage.scala
+++ b/app/pages/adminServices/StrideOrInternalAuthPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.adminServices
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object StrideOrInternalAuthPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "strideOrInternalAuth"
+}

--- a/app/pages/adminServices/StrideOrVPNPage.scala
+++ b/app/pages/adminServices/StrideOrVPNPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.adminServices
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object StrideOrVPNPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "strideOrVPN"
+}

--- a/app/viewmodels/checkAnswers/adminServices/AccessProductionAdminFrontendSummary.scala
+++ b/app/viewmodels/checkAnswers/adminServices/AccessProductionAdminFrontendSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.adminServices
+
+import controllers.adminServices.routes
+import models.{CheckMode, UserAnswers}
+import pages.adminServices.AccessProductionAdminFrontendPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object AccessProductionAdminFrontendSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(AccessProductionAdminFrontendPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "accessProductionAdminFrontend.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.AccessProductionAdminFrontendController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("accessProductionAdminFrontend.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/adminServices/NoPublicRouteSummary.scala
+++ b/app/viewmodels/checkAnswers/adminServices/NoPublicRouteSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.adminServices
+
+import controllers.adminServices.routes
+import models.{CheckMode, UserAnswers}
+import pages.adminServices.NoPublicRoutePage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object NoPublicRouteSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(NoPublicRoutePage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "noPublicRoute.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.NoPublicRouteController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("noPublicRoute.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/adminServices/StrideOrInternalAuthSummary.scala
+++ b/app/viewmodels/checkAnswers/adminServices/StrideOrInternalAuthSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.adminServices
+
+import controllers.adminServices.routes
+import models.{CheckMode, UserAnswers}
+import pages.adminServices.StrideOrInternalAuthPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object StrideOrInternalAuthSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(StrideOrInternalAuthPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "strideOrInternalAuth.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.StrideOrInternalAuthController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("strideOrInternalAuth.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/adminServices/StrideOrVPNSummary.scala
+++ b/app/viewmodels/checkAnswers/adminServices/StrideOrVPNSummary.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.adminServices
+
+import controllers.adminServices.routes
+import models.{CheckMode, UserAnswers}
+import pages.adminServices.StrideOrVPNPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object StrideOrVPNSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(StrideOrVPNPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "strideOrVPN.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.StrideOrVPNController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("strideOrVPN.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/views/adminServices/AccessProductionAdminFrontendView.scala.html
+++ b/app/views/adminServices/AccessProductionAdminFrontendView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("accessProductionAdminFrontend.title"))) {
+
+    @formHelper(action = controllers.adminServices.routes.AccessProductionAdminFrontendController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("accessProductionAdminFrontend.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/adminServices/CheckYourAnswersView.scala.html
+++ b/app/views/adminServices/CheckYourAnswersView.scala.html
@@ -14,12 +14,9 @@
  * limitations under the License.
  *@
 
-@import controllers.adminServices.routes as adminServicesRoutes
-
 @this(
     layout: templates.Layout,
-    govukSummaryList: GovukSummaryList,
-    govukButton: GovukButton
+    govukSummaryList: GovukSummaryList
 )
 
 @(list: SummaryList)(implicit request: Request[_], messages: Messages)
@@ -29,13 +26,5 @@
     <h1 class="govuk-heading-xl">@messages("checkYourAnswers.heading")</h1>
 
     @govukSummaryList(list)
-
-    <div>
-        @govukButton(
-        ButtonViewModel(messages("site.continue"))
-            .withAttribute("id","continue")
-            .asLink(adminServicesRoutes.NoPublicRouteController.onPageLoad(NormalMode).url)
-        )
-    </div>
 
 }

--- a/app/views/adminServices/NoPublicRouteView.scala.html
+++ b/app/views/adminServices/NoPublicRouteView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("noPublicRoute.title"))) {
+
+    @formHelper(action = controllers.adminServices.routes.NoPublicRouteController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("noPublicRoute.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/adminServices/StrideOrInternalAuthView.scala.html
+++ b/app/views/adminServices/StrideOrInternalAuthView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("strideOrInternalAuth.title"))) {
+
+    @formHelper(action = controllers.adminServices.routes.StrideOrInternalAuthController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("strideOrInternalAuth.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/adminServices/StrideOrVPNView.scala.html
+++ b/app/views/adminServices/StrideOrVPNView.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("strideOrVPN.title"))) {
+
+    @formHelper(action = controllers.adminServices.routes.StrideOrVPNController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("strideOrVPN.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/conf/adminServices.routes
+++ b/conf/adminServices.routes
@@ -1,0 +1,22 @@
+
+GET        /no-public-route                              controllers.adminServices.NoPublicRouteController.onPageLoad(mode: Mode = NormalMode)
+POST       /no-public-route                              controllers.adminServices.NoPublicRouteController.onSubmit(mode: Mode = NormalMode)
+GET        /change-no-public-route                       controllers.adminServices.NoPublicRouteController.onPageLoad(mode: Mode = CheckMode)
+POST       /change-no-public-route                       controllers.adminServices.NoPublicRouteController.onSubmit(mode: Mode = CheckMode)
+
+GET        /stride-or-vpn                                controllers.adminServices.StrideOrVPNController.onPageLoad(mode: Mode = NormalMode)
+POST       /stride-or-vpn                                controllers.adminServices.StrideOrVPNController.onSubmit(mode: Mode = NormalMode)
+GET        /change-stride-or-vpn                         controllers.adminServices.StrideOrVPNController.onPageLoad(mode: Mode = CheckMode)
+POST       /change-stride-or-vpn                         controllers.adminServices.StrideOrVPNController.onSubmit(mode: Mode = CheckMode)
+
+GET        /stride-or-internal-auth                      controllers.adminServices.StrideOrInternalAuthController.onPageLoad(mode: Mode = NormalMode)
+POST       /stride-or-internal-auth                      controllers.adminServices.StrideOrInternalAuthController.onSubmit(mode: Mode = NormalMode)
+GET        /change-stride-or-internal-auth               controllers.adminServices.StrideOrInternalAuthController.onPageLoad(mode: Mode = CheckMode)
+POST       /change-stride-or-internal-auth               controllers.adminServices.StrideOrInternalAuthController.onSubmit(mode: Mode = CheckMode)
+
+GET        /access-production-admin-frontend             controllers.adminServices.AccessProductionAdminFrontendController.onPageLoad(mode: Mode = NormalMode)
+POST       /access-production-admin-frontend             controllers.adminServices.AccessProductionAdminFrontendController.onSubmit(mode: Mode = NormalMode)
+GET        /change-access-production-admin-frontend      controllers.adminServices.AccessProductionAdminFrontendController.onPageLoad(mode: Mode = CheckMode)
+POST       /change-access-production-admin-frontend      controllers.adminServices.AccessProductionAdminFrontendController.onSubmit(mode: Mode = CheckMode)
+
+GET        /check-your-answers                           controllers.adminServices.CheckYourAnswersController.onPageLoad()

--- a/conf/adminServices.routes
+++ b/conf/adminServices.routes
@@ -1,4 +1,3 @@
-
 GET        /no-public-route                              controllers.adminServices.NoPublicRouteController.onPageLoad(mode: Mode = NormalMode)
 POST       /no-public-route                              controllers.adminServices.NoPublicRouteController.onSubmit(mode: Mode = NormalMode)
 GET        /change-no-public-route                       controllers.adminServices.NoPublicRouteController.onPageLoad(mode: Mode = CheckMode)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -10,6 +10,8 @@
 
 ->          /security                                    security.Routes
 
+->          /admin-services                              adminServices.Routes
+
 GET         /                                            controllers.IndexController.onPageLoad()
 
 GET         /assets/*file                                controllers.Assets.versioned(path="/public", file: Asset)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -216,3 +216,31 @@ protectedMicroserviceAuth.checkYourAnswersLabel =  Protected Microservices shoul
 protectedMicroserviceAuth.error.required = Select yes if  Protected Microservices are being authenticated and authorised by default.
 protectedMicroserviceAuth.change.hidden = ProtectedMicroserviceAuth
 protectedMicroserviceAuth.hint = Internal Auth is an option for service-to-service authentication.
+
+#========================================
+#            Admin Services
+#========================================
+
+noPublicRoute.title = Does your service have Public Routing to the service in MDTP Frontend Routes?
+noPublicRoute.heading = Does your service have Public Routing to the service in MDTP Frontend Routes?
+noPublicRoute.checkYourAnswersLabel = Does your service have Public Routing to the service in MDTP Frontend Routes?
+noPublicRoute.error.required = Select yes if your admin service has a public routing to the service in the MDTP Frontend Routes
+noPublicRoute.change.hidden = NoPublicRoute
+
+strideOrVPN.title = Is your admin service only accessible either on the HMRC VPN or by using a Stride device?
+strideOrVPN.heading = Is your admin service only accessible either on the HMRC VPN or by using a Stride device?
+strideOrVPN.checkYourAnswersLabel = Is your admin service only accessible either on the HMRC VPN or by using a Stride device?
+strideOrVPN.error.required = Select yes if your admin service only accessible either on the HMRC VPN or by using a Stride device
+strideOrVPN.change.hidden = StrideOrVPN
+
+strideOrInternalAuth.title = Is access to this service restricted to Stride or an Internal Auth?
+strideOrInternalAuth.heading = Is access to this service restricted to Stride or an Internal Auth?
+strideOrInternalAuth.checkYourAnswersLabel = Is access to this service restricted to Stride or an Internal Auth?
+strideOrInternalAuth.error.required = Select yes if access to this service restricted to Stride or an Internal Auth
+strideOrInternalAuth.change.hidden = StrideOrInternalAuth
+
+accessProductionAdminFrontend.title = Has access to the Production Admin Service Frontend been specified in conjunction with your Risk Assessor?
+accessProductionAdminFrontend.heading = Has access to the Production Admin Service Frontend been specified in conjunction with your Risk Assessor?
+accessProductionAdminFrontend.checkYourAnswersLabel = Has access to the Production Admin Service Frontend been specified in conjunction with your Risk Assessor?
+accessProductionAdminFrontend.error.required = Select yes if access to the Production Admin Service Frontend been specified in conjunction with your Risk Assessor
+accessProductionAdminFrontend.change.hidden = AccessProductionAdminFrontend

--- a/test/controllers/adminServices/AccessProductionAdminFrontendControllerSpec.scala
+++ b/test/controllers/adminServices/AccessProductionAdminFrontendControllerSpec.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.adminServices
+
+import controllers.routes
+import controllers.adminServices.routes as adminServicesRoutes
+
+import base.SpecBase
+import forms.adminServices.AccessProductionAdminFrontendFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.adminServices.AccessProductionAdminFrontendPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import services.SessionService
+import play.api.mvc.Results.NoContent
+import views.html.adminServices.AccessProductionAdminFrontendView
+
+import scala.concurrent.Future
+
+class AccessProductionAdminFrontendControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new AccessProductionAdminFrontendFormProvider()
+  val form = formProvider()
+
+  lazy val accessProductionAdminFrontendRoute = adminServicesRoutes.AccessProductionAdminFrontendController.onPageLoad(NormalMode).url
+
+  "AccessProductionAdminFrontend Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, accessProductionAdminFrontendRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[AccessProductionAdminFrontendView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(AccessProductionAdminFrontendPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, accessProductionAdminFrontendRoute)
+
+        val view = application.injector.instanceOf[AccessProductionAdminFrontendView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionService = mock[SessionService]
+
+      when(mockSessionService.setUserAnswers(any())(any())) thenReturn Future.successful(NoContent)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionService].toInstance(mockSessionService)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, accessProductionAdminFrontendRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, accessProductionAdminFrontendRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[AccessProductionAdminFrontendView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, accessProductionAdminFrontendRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, accessProductionAdminFrontendRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/adminServices/AccessProductionAdminFrontendControllerSpec.scala
+++ b/test/controllers/adminServices/AccessProductionAdminFrontendControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.adminServices.routes as adminServicesRoutes
 import base.SpecBase
 import forms.adminServices.AccessProductionAdminFrontendFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import navigation.{FakeAdminServicesNavigator, AdminServicesNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -91,7 +91,7 @@ class AccessProductionAdminFrontendControllerSpec extends SpecBase with MockitoS
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[AdminServicesNavigator].toInstance(new FakeAdminServicesNavigator(onwardRoute)),
             bind[SessionService].toInstance(mockSessionService)
           )
           .build()

--- a/test/controllers/adminServices/NoPublicRouteControllerSpec.scala
+++ b/test/controllers/adminServices/NoPublicRouteControllerSpec.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.adminServices
+
+import controllers.routes
+import controllers.adminServices.routes as adminServicesRoutes
+
+import base.SpecBase
+import forms.adminServices.NoPublicRouteFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.adminServices.NoPublicRoutePage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import services.SessionService
+import play.api.mvc.Results.NoContent
+import views.html.adminServices.NoPublicRouteView
+
+import scala.concurrent.Future
+
+class NoPublicRouteControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new NoPublicRouteFormProvider()
+  val form = formProvider()
+
+  lazy val noPublicRouteRoute = adminServicesRoutes.NoPublicRouteController.onPageLoad(NormalMode).url
+
+  "NoPublicRoute Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, noPublicRouteRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[NoPublicRouteView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(NoPublicRoutePage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, noPublicRouteRoute)
+
+        val view = application.injector.instanceOf[NoPublicRouteView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionService = mock[SessionService]
+
+      when(mockSessionService.setUserAnswers(any())(any())) thenReturn Future.successful(NoContent)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionService].toInstance(mockSessionService)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, noPublicRouteRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, noPublicRouteRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[NoPublicRouteView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, noPublicRouteRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, noPublicRouteRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/adminServices/NoPublicRouteControllerSpec.scala
+++ b/test/controllers/adminServices/NoPublicRouteControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.adminServices.routes as adminServicesRoutes
 import base.SpecBase
 import forms.adminServices.NoPublicRouteFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import navigation.{FakeAdminServicesNavigator, AdminServicesNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -91,7 +91,7 @@ class NoPublicRouteControllerSpec extends SpecBase with MockitoSugar {
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[AdminServicesNavigator].toInstance(new FakeAdminServicesNavigator(onwardRoute)),
             bind[SessionService].toInstance(mockSessionService)
           )
           .build()

--- a/test/controllers/adminServices/StrideOrInternalAuthControllerSpec.scala
+++ b/test/controllers/adminServices/StrideOrInternalAuthControllerSpec.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.adminServices
+
+import controllers.routes
+import controllers.adminServices.routes as adminServicesRoutes
+
+import base.SpecBase
+import forms.adminServices.StrideOrInternalAuthFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.adminServices.StrideOrInternalAuthPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import services.SessionService
+import play.api.mvc.Results.NoContent
+import views.html.adminServices.StrideOrInternalAuthView
+
+import scala.concurrent.Future
+
+class StrideOrInternalAuthControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new StrideOrInternalAuthFormProvider()
+  val form = formProvider()
+
+  lazy val strideOrInternalAuthRoute = adminServicesRoutes.StrideOrInternalAuthController.onPageLoad(NormalMode).url
+
+  "StrideOrInternalAuth Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, strideOrInternalAuthRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[StrideOrInternalAuthView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(StrideOrInternalAuthPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, strideOrInternalAuthRoute)
+
+        val view = application.injector.instanceOf[StrideOrInternalAuthView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionService = mock[SessionService]
+
+      when(mockSessionService.setUserAnswers(any())(any())) thenReturn Future.successful(NoContent)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionService].toInstance(mockSessionService)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, strideOrInternalAuthRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, strideOrInternalAuthRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[StrideOrInternalAuthView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, strideOrInternalAuthRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, strideOrInternalAuthRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/adminServices/StrideOrInternalAuthControllerSpec.scala
+++ b/test/controllers/adminServices/StrideOrInternalAuthControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.adminServices.routes as adminServicesRoutes
 import base.SpecBase
 import forms.adminServices.StrideOrInternalAuthFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import navigation.{FakeAdminServicesNavigator, AdminServicesNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -91,7 +91,7 @@ class StrideOrInternalAuthControllerSpec extends SpecBase with MockitoSugar {
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[AdminServicesNavigator].toInstance(new FakeAdminServicesNavigator(onwardRoute)),
             bind[SessionService].toInstance(mockSessionService)
           )
           .build()

--- a/test/controllers/adminServices/StrideOrVPNControllerSpec.scala
+++ b/test/controllers/adminServices/StrideOrVPNControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.adminServices.routes as adminServicesRoutes
 import base.SpecBase
 import forms.adminServices.StrideOrVPNFormProvider
 import models.{NormalMode, UserAnswers}
-import navigation.{FakeNavigator, Navigator}
+import navigation.{FakeAdminServicesNavigator, AdminServicesNavigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -91,7 +91,7 @@ class StrideOrVPNControllerSpec extends SpecBase with MockitoSugar {
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
-            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[AdminServicesNavigator].toInstance(new FakeAdminServicesNavigator(onwardRoute)),
             bind[SessionService].toInstance(mockSessionService)
           )
           .build()

--- a/test/controllers/adminServices/StrideOrVPNControllerSpec.scala
+++ b/test/controllers/adminServices/StrideOrVPNControllerSpec.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.adminServices
+
+import controllers.routes
+import controllers.adminServices.routes as adminServicesRoutes
+
+import base.SpecBase
+import forms.adminServices.StrideOrVPNFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.adminServices.StrideOrVPNPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import services.SessionService
+import play.api.mvc.Results.NoContent
+import views.html.adminServices.StrideOrVPNView
+
+import scala.concurrent.Future
+
+class StrideOrVPNControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new StrideOrVPNFormProvider()
+  val form = formProvider()
+
+  lazy val strideOrVPNRoute = adminServicesRoutes.StrideOrVPNController.onPageLoad(NormalMode).url
+
+  "StrideOrVPN Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, strideOrVPNRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[StrideOrVPNView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(StrideOrVPNPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, strideOrVPNRoute)
+
+        val view = application.injector.instanceOf[StrideOrVPNView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionService = mock[SessionService]
+
+      when(mockSessionService.setUserAnswers(any())(any())) thenReturn Future.successful(NoContent)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionService].toInstance(mockSessionService)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, strideOrVPNRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, strideOrVPNRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[StrideOrVPNView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, strideOrVPNRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, strideOrVPNRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/forms/adminServices/AccessProductionAdminFrontendFormProviderSpec.scala
+++ b/test/forms/adminServices/AccessProductionAdminFrontendFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.adminServices
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class AccessProductionAdminFrontendFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "accessProductionAdminFrontend.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new AccessProductionAdminFrontendFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/adminServices/NoPublicRouteFormProviderSpec.scala
+++ b/test/forms/adminServices/NoPublicRouteFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.adminServices
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class NoPublicRouteFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "noPublicRoute.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new NoPublicRouteFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/adminServices/StrideOrInternalAuthFormProviderSpec.scala
+++ b/test/forms/adminServices/StrideOrInternalAuthFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.adminServices
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class StrideOrInternalAuthFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "strideOrInternalAuth.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new StrideOrInternalAuthFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/adminServices/StrideOrVPNFormProviderSpec.scala
+++ b/test/forms/adminServices/StrideOrVPNFormProviderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.adminServices
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class StrideOrVPNFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "strideOrVPN.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new StrideOrVPNFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/navigation/AdminServicesNavigatorSpec.scala
+++ b/test/navigation/AdminServicesNavigatorSpec.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package navigation
+
+import base.SpecBase
+import controllers.routes
+import controllers.adminServices.routes as adminServicesRoutes
+import models.*
+import pages.*
+import pages.adminServices.{AccessProductionAdminFrontendPage, NoPublicRoutePage, StrideOrInternalAuthPage, StrideOrVPNPage}
+
+class AdminServicesNavigatorSpec extends SpecBase {
+
+  val navigator = new AdminServicesNavigator
+
+  "AdminServicesNavigator" - {
+
+    "in Normal mode" - {
+
+      "must go from a page that doesn't exist in the route map to Index" in {
+        case object UnknownPage extends Page
+        navigator.nextPage(UnknownPage, NormalMode, UserAnswers("id")) mustBe routes.IndexController.onPageLoad()
+      }
+
+      "must go from the No Public Routes page to Stride or VPN page" in {
+        navigator.nextPage(NoPublicRoutePage, NormalMode, UserAnswers("id")) mustBe adminServicesRoutes.StrideOrVPNController.onPageLoad(NormalMode)
+      }
+      "must go from the Stride or VPN page to Stride or Internal Auth page" in {
+        navigator.nextPage(StrideOrVPNPage, NormalMode, UserAnswers("id")) mustBe adminServicesRoutes.StrideOrInternalAuthController.onPageLoad(NormalMode)
+      }
+      "must go from Stride or Internal Auth page to Access Prod Admin Frontend Page" in {
+        navigator.nextPage(StrideOrInternalAuthPage, NormalMode, UserAnswers("id")) mustBe adminServicesRoutes.AccessProductionAdminFrontendController.onPageLoad(NormalMode)
+      }
+      "must go from Access Prod Admin Frontend page to Check Your Answers Page" in {
+        navigator.nextPage(AccessProductionAdminFrontendPage, NormalMode, UserAnswers("id")) mustBe adminServicesRoutes.CheckYourAnswersController.onPageLoad()
+      }
+    }
+
+
+    "in Check mode" - {
+
+      "must go from the No Public Route page to the Stride or VPN page WHEN Stride or VPN Page does not have an Answer" in {
+        navigator.nextPage(NoPublicRoutePage, CheckMode, UserAnswers("id")) mustBe adminServicesRoutes.StrideOrVPNController.onPageLoad(CheckMode)
+      }
+      "must go from the No Public Routes page to the Check Your Answers page WHEN Stride or VPN page has an Answer" in {
+        UserAnswers("id").set(StrideOrVPNPage, true).foreach { userAnswers =>
+          navigator.nextPage(NoPublicRoutePage, CheckMode, userAnswers) mustBe adminServicesRoutes.CheckYourAnswersController.onPageLoad()
+        }
+      }
+
+      "must go from the Stride or VPN page to the Stride or Internal Auth page WHEN Stride or Internal Auth Page does not have an Answer" in {
+        navigator.nextPage(StrideOrVPNPage, CheckMode, UserAnswers("id")) mustBe adminServicesRoutes.StrideOrInternalAuthController.onPageLoad(CheckMode)
+      }
+      "must go from the Stride or VPN page to the Check Your Answers page WHEN Protected Microservices Auth page has an Answer" in {
+        UserAnswers("id").set(StrideOrInternalAuthPage, true).foreach { userAnswers =>
+          navigator.nextPage(StrideOrVPNPage, CheckMode, userAnswers) mustBe adminServicesRoutes.CheckYourAnswersController.onPageLoad()
+        }
+      }
+
+      "must go from the Stride or Internal Auth page to the Access Prod Admin Frontend page WHEN Access Prod Admin Frontend Page does not have an Answer" in {
+        navigator.nextPage(StrideOrInternalAuthPage, CheckMode, UserAnswers("id")) mustBe adminServicesRoutes.AccessProductionAdminFrontendController.onPageLoad(CheckMode)
+      }
+      "must go from the Stride or Internal Auth page to the Check Your Answers page WHEN Access Prod Admin Frontend page has an Answer" in {
+        UserAnswers("id").set(AccessProductionAdminFrontendPage, true).foreach { userAnswers =>
+          navigator.nextPage(StrideOrInternalAuthPage, CheckMode, userAnswers) mustBe adminServicesRoutes.CheckYourAnswersController.onPageLoad()
+        }
+      }
+      
+      "must go from Access Prod Admin Frontend page to Check Your Answers Page" in {
+        navigator.nextPage(AccessProductionAdminFrontendPage, CheckMode, UserAnswers("id")) mustBe adminServicesRoutes.CheckYourAnswersController.onPageLoad()
+      }
+
+      "must go from a page that doesn't exist in the edit route map to CheckYourAnswers" in {
+        case object UnknownPage extends Page
+        navigator.nextPage(UnknownPage, CheckMode, UserAnswers("id")) mustBe adminServicesRoutes.CheckYourAnswersController.onPageLoad()
+      }
+    }
+  }
+}
+

--- a/test/navigation/FakeAdminServicesNavigator.scala
+++ b/test/navigation/FakeAdminServicesNavigator.scala
@@ -20,7 +20,7 @@ import models.{Mode, UserAnswers}
 import pages.*
 import play.api.mvc.Call
 
-class FakeAdminServicesNavigator(desiredRoute: Call) extends Navigator {
+class FakeAdminServicesNavigator(desiredRoute: Call) extends AdminServicesNavigator {
 
   override def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers): Call =
     desiredRoute

--- a/test/navigation/FakeAdminServicesNavigator.scala
+++ b/test/navigation/FakeAdminServicesNavigator.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package navigation
+
+import models.{Mode, UserAnswers}
+import pages.*
+import play.api.mvc.Call
+
+class FakeAdminServicesNavigator(desiredRoute: Call) extends Navigator {
+
+  override def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers): Call =
+    desiredRoute
+}


### PR DESCRIPTION
Added new Section 5: Admin Services journey to follow from Section 4: Security;

- `/security/check-your-answers` => `/admin-services/no-public-route`
- `/admin-services/no-public-route` => `/admin-services/stride-or-vpn`
- `/admin-services/stride-or-vpn` => `/admin-services/stride-or-internal-auth`
- `/admin-services/stride-or-internal-auth` => `/admin-services/access-production-admin-frontend`
- `/admin-services/access-production-admin-frontend` => `/admin-services/check-your-answers`